### PR TITLE
fix: Distance in the example map format

### DIFF
--- a/openlr_dereferencer/example_sqlite_map/__init__.py
+++ b/openlr_dereferencer/example_sqlite_map/__init__.py
@@ -60,15 +60,15 @@ class ExampleMapReader(MapReader):
     def find_nodes_close_to(self, coord: Coordinates, dist: float) -> Iterable[Node]:
         """Finds all nodes in a given radius, given in meters
 
-        Yields every node with its meter distance to `coord`."""
+        Yields every node within this distance to `coord`."""
         lon, lat = coord.lon, coord.lat
         stmt = """SELECT id FROM nodes WHERE Distance(MakePoint(?, ?), coord, 0) < ?"""
         for (node_id,) in self.connection.execute(stmt, (lon, lat, dist)):
             yield Node(self, node_id)
 
     def find_lines_close_to(self, coord: Coordinates, dist: float) -> Iterable[Line]:
-        "Yields all lines in a given radius"
+        "Yields all lines within `dist` meters around `coord`"
         lon, lat = coord.lon, coord.lat
-        stmt = """SELECT rowid FROM lines WHERE Distance(MakePoint(?, ?), path, 0) < ?"""
+        stmt = """SELECT rowid FROM lines WHERE PtDistWithin(MakePoint(?, ?), path, ?, 0)"""
         for (line_id,) in self.connection.execute(stmt, (lon, lat, dist)):
             yield Line(self, line_id)

--- a/openlr_dereferencer/example_sqlite_map/__init__.py
+++ b/openlr_dereferencer/example_sqlite_map/__init__.py
@@ -62,13 +62,13 @@ class ExampleMapReader(MapReader):
 
         Yields every node with its meter distance to `coord`."""
         lon, lat = coord.lon, coord.lat
-        stmt = """SELECT id FROM nodes WHERE Distance(MakePoint(?, ?), coord, 1) < ?"""
+        stmt = """SELECT id FROM nodes WHERE Distance(MakePoint(?, ?), coord, 0) < ?"""
         for (node_id,) in self.connection.execute(stmt, (lon, lat, dist)):
             yield Node(self, node_id)
 
     def find_lines_close_to(self, coord: Coordinates, dist: float) -> Iterable[Line]:
         "Yields all lines in a given radius"
         lon, lat = coord.lon, coord.lat
-        stmt = """SELECT rowid FROM lines WHERE Distance(MakePoint(?, ?), path) < ?"""
+        stmt = """SELECT rowid FROM lines WHERE Distance(MakePoint(?, ?), path, 0) < ?"""
         for (line_id,) in self.connection.execute(stmt, (lon, lat, dist)):
             yield Line(self, line_id)

--- a/openlr_dereferencer/example_sqlite_map/primitives.py
+++ b/openlr_dereferencer/example_sqlite_map/primitives.py
@@ -67,6 +67,8 @@ class Line(AbstractLine):
             FROM nodes, lines WHERE lines.rowid = ?"""
         con = self.map_reader.connection
         (dist,) = con.execute(stmt, (coord.lon, coord.lat, self.line_id)).fetchone()
+        # Details about a bug in mod_spatialite:
+        # https://gis.stackexchange.com/questions/359993/spatialite-distance-returns-null-when-geometries-touch
         if dist is None:
             return 0.0
         else:

--- a/openlr_dereferencer/example_sqlite_map/primitives.py
+++ b/openlr_dereferencer/example_sqlite_map/primitives.py
@@ -67,7 +67,10 @@ class Line(AbstractLine):
             FROM nodes, lines WHERE lines.rowid = ?"""
         con = self.map_reader.connection
         (dist,) = con.execute(stmt, (coord.lon, coord.lat, self.line_id)).fetchone()
-        return dist
+        if dist is None:
+            return 0.0
+        else:
+            return dist
 
     def num_points(self) -> int:
         "Returns how many points the path geometry contains"

--- a/openlr_dereferencer/example_sqlite_map/primitives.py
+++ b/openlr_dereferencer/example_sqlite_map/primitives.py
@@ -63,7 +63,7 @@ class Line(AbstractLine):
 
     def distance_to(self, coord) -> float:
         "Returns the distance of this line to `coord` in meters"
-        stmt = """SELECT Distance(Makepoint(?, ?), lines.path)
+        stmt = """SELECT Distance(Makepoint(?, ?), lines.path, 1)
             FROM nodes, lines WHERE lines.rowid = ?"""
         con = self.map_reader.connection
         (dist,) = con.execute(stmt, (coord.lon, coord.lat, self.line_id)).fetchone()


### PR DESCRIPTION
Wrong usage of SpatiaLite's Distance function leads to returning many more nodes than intended.