### PR TITLE
Let user pass configuration object

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,14 @@ logging.basicConfig(level=logging.DEBUG)
 ```
 
 ## Observing
-Via implementing the [Observer](https://openlr-dereferencer-python.readthedocs.io/en/latest/openlr_dereferencer.observer.html#openlr_dereferencer.observer.simple_observer.SimpleObserver) interface
+Via implementing the [Observer](https://openlr-dereferencer-python.readthedocs.io/en/latest/openlr_dereferencer.observer.html#openlr_dereferencer.observer.simple_observer.SimpleObserver) interface, you can hook onto certain events happening while decoding, and inspect the situation:
+```py
+from openlr_dereferencer import DecoderObserver, SimpleObserver
+
+# Look at SimpleObserver for an example implementation
+my_observer = SimpleObserver()
+decode(reference, mapreader, observer=my_observer)
+```
 
 ## Development environment
 

--- a/README.md
+++ b/README.md
@@ -60,32 +60,24 @@ real_location.lines # <- A list of map objects
 ```
 
 ## Configuration
-### Candidates
-The configuration value `openlr_dereferencer.SEARCH_RADIUS` determines how far away from the LRP road candidates are searched.
-The unit is meters, the default 100.
-### Scores
-Every candidate line gets a score from `0` (bad) to `1` (perfect).
-
-There are four scoring weight parameters:
- - GEO_WEIGHT = 0.25
- - FRC_WEIGHT = 0.25
- - FOW_WEIGHT = 0.25
- - BEAR_WEIGHT = 0.25
-
-They determine how much influence a single aspect has on an overall candidate's score.
- 
+The `decode` function takes in an optional `Config` object contaning decoding settings.
 You may just change these before decoding:
 ```py
-from openlr_dereferencer.decoding import scoring
+from openlr_dereferencer import decode, Config
 
-scoring.GEO_WEIGHT = 0.66
-scoring.FRC_WEIGHT = 0.17
-scoring.FOW_WEIGHT = 0.17
-scoring.BEAR_WEIGHT = 0
+my_config = Config(
+    geo_weight = 0.66,
+    frc_height = 0.17,
+    fow_height = 0.17,
+    bear_weight = 0.0
+)
+
+decode(reference, mapreader, config=my_config)
 ```
 
-A value of 0 means that the aspect has no influence on the candidate score, while a value of 1 means that it is the only aspect that matters.
-### Logging
+The full list of available options is located [here](https://openlr-dereferencer-python.readthedocs.io/en/latest/openlr_dereferencer.decoding.html#openlr_dereferencer.decoding.configuration.Config).
+
+## Logging
 `openlr-dereferencer` logs all mapmatching decisions using the standard library `logging` module.
 
 Use it to turn on debugging:
@@ -94,6 +86,9 @@ import logging
 
 logging.basicConfig(level=logging.DEBUG)
 ```
+
+## Observing
+Via implementing the [Observer](https://openlr-dereferencer-python.readthedocs.io/en/latest/openlr_dereferencer.observer.html#openlr_dereferencer.observer.simple_observer.SimpleObserver) interface
 
 ## Development environment
 

--- a/docs/source/openlr_dereferencer.decoding.rst
+++ b/docs/source/openlr_dereferencer.decoding.rst
@@ -4,10 +4,26 @@ openlr\_dereferencer.decoding package
 Submodules
 ----------
 
+openlr\_dereferencer.decoding.candidate module
+----------------------------------------------
+
+.. automodule:: openlr_dereferencer.decoding.candidate
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 openlr\_dereferencer.decoding.candidates module
 -----------------------------------------------
 
 .. automodule:: openlr_dereferencer.decoding.candidates
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+openlr\_dereferencer.decoding.configuration module
+--------------------------------------------------
+
+.. automodule:: openlr_dereferencer.decoding.configuration
    :members:
    :undoc-members:
    :show-inheritance:
@@ -32,6 +48,14 @@ openlr\_dereferencer.decoding.point\_locations module
 -----------------------------------------------------
 
 .. automodule:: openlr_dereferencer.decoding.point_locations
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+openlr\_dereferencer.decoding.routes module
+-------------------------------------------
+
+.. automodule:: openlr_dereferencer.decoding.routes
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/openlr_dereferencer.decoding.rst
+++ b/docs/source/openlr_dereferencer.decoding.rst
@@ -27,7 +27,6 @@ openlr\_dereferencer.decoding.configuration module
    :members:
    :undoc-members:
    :show-inheritance:
-   :autodoc_member_order:
 
 openlr\_dereferencer.decoding.line\_decoding module
 ---------------------------------------------------

--- a/docs/source/openlr_dereferencer.decoding.rst
+++ b/docs/source/openlr_dereferencer.decoding.rst
@@ -27,6 +27,7 @@ openlr\_dereferencer.decoding.configuration module
    :members:
    :undoc-members:
    :show-inheritance:
+   :autodoc_member_order:
 
 openlr\_dereferencer.decoding.line\_decoding module
 ---------------------------------------------------

--- a/docs/source/openlr_dereferencer.observer.rst
+++ b/docs/source/openlr_dereferencer.observer.rst
@@ -1,0 +1,30 @@
+openlr\_dereferencer.observer package
+=====================================
+
+Submodules
+----------
+
+openlr\_dereferencer.observer.abstract module
+---------------------------------------------
+
+.. automodule:: openlr_dereferencer.observer.abstract
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+openlr\_dereferencer.observer.simple\_observer module
+-----------------------------------------------------
+
+.. automodule:: openlr_dereferencer.observer.simple_observer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: openlr_dereferencer.observer
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/openlr_dereferencer.rst
+++ b/docs/source/openlr_dereferencer.rst
@@ -10,6 +10,7 @@ Subpackages
    openlr_dereferencer.decoding
    openlr_dereferencer.example_sqlite_map
    openlr_dereferencer.maps
+   openlr_dereferencer.observer
 
 Module contents
 ---------------

--- a/openlr_dereferencer/__init__.py
+++ b/openlr_dereferencer/__init__.py
@@ -3,7 +3,8 @@
 OpenLR line decoder package.
 """
 
-from .decoding import decode, Config
+from .decoding import decode, Config, load_config, save_config, DEFAULT_CONFIG
+from .observer import DecoderObserver, SimpleObserver
 
 from ._version import (
     __title__,

--- a/openlr_dereferencer/__init__.py
+++ b/openlr_dereferencer/__init__.py
@@ -3,7 +3,7 @@
 OpenLR line decoder package.
 """
 
-from .decoding import decode_line, decode, SEARCH_RADIUS
+from .decoding import decode, Config
 
 from ._version import (
     __title__,

--- a/openlr_dereferencer/decoding/__init__.py
+++ b/openlr_dereferencer/decoding/__init__.py
@@ -20,7 +20,7 @@ from .point_locations import (
     decode_poi_with_accesspoint,
     PoiWithAccessPoint,
 )
-from .configuration import Config, DEFAULT_CONFIG
+from .configuration import Config, DEFAULT_CONFIG, load_config, save_config
 
 LR = TypeVar("LocationReference", LineLocationRef, PointAlongLineLocation, GeoCoordinateLocation)
 MAP_OBJECTS = TypeVar("MapObjects", LineLocation, Coordinates, PointAlongLine)

--- a/openlr_dereferencer/decoding/__init__.py
+++ b/openlr_dereferencer/decoding/__init__.py
@@ -20,15 +20,17 @@ from .point_locations import (
     decode_poi_with_accesspoint,
     PoiWithAccessPoint,
 )
-
-#: Configures the default radius to search for map objects around an LRP. This value is in meters.
-SEARCH_RADIUS = 100.0
+from .configuration import Config, DEFAULT_CONFIG
 
 LR = TypeVar("LocationReference", LineLocationRef, PointAlongLineLocation, GeoCoordinateLocation)
 MAP_OBJECTS = TypeVar("MapObjects", LineLocation, Coordinates, PointAlongLine)
 
-def decode(reference: LR, reader: MapReader, radius: float = SEARCH_RADIUS, observer: Optional[DecoderObserver] = None
-    ) -> MAP_OBJECTS:
+def decode(
+    reference: LR, 
+    reader: MapReader,
+    observer: Optional[DecoderObserver] = None,
+    config: Config=DEFAULT_CONFIG
+) -> MAP_OBJECTS:
     """Translates an openLocationReference into a real location on your map.
 
     Args:
@@ -41,6 +43,8 @@ def decode(reference: LR, reader: MapReader, radius: float = SEARCH_RADIUS, obse
             The search path for the location's components' candidates
         observer:
             An observer that collects information when events of interest happen at the decoder
+        config:
+            A definition of the decoding behaviour providing various settings
 
     Returns:
         This function will return one or more map object, optionally wrapped into some class.
@@ -59,13 +63,13 @@ def decode(reference: LR, reader: MapReader, radius: float = SEARCH_RADIUS, obse
         +-----------------------------------+----------------------------------+
     """
     if isinstance(reference, LineLocationRef):
-        return decode_line(reference, reader, radius, observer)
+        return decode_line(reference, reader, config, observer)
     elif isinstance(reference, PointAlongLineLocation):
-        return decode_pointalongline(reference, reader, radius, observer)
+        return decode_pointalongline(reference, reader, config, observer)
     elif isinstance(reference, GeoCoordinateLocation):
         return reference.point
     elif isinstance(reference, PoiWithAccessPointLocation):
-        return decode_poi_with_accesspoint(reference, reader, radius, observer)
+        return decode_poi_with_accesspoint(reference, reader, config, observer)
     else:
         raise LRDecodeError(
             "Currently, the following reference types are supported:\n"

--- a/openlr_dereferencer/decoding/candidates.py
+++ b/openlr_dereferencer/decoding/candidates.py
@@ -53,9 +53,9 @@ def get_candidate_route(
         line2:
             The end line.
         lfrc:
-            "lowest frc".
-            Line objects from map_reader with an FRC lower than lfrc will be ignored.
-        maxlen: Pathfinding will be canceled after exceeding a length of maxlen.
+            "lowest frc". Line objects from map_reader with an FRC lower than lfrc will be ignored.
+        maxlen:
+            Pathfinding will be canceled after exceeding a length of maxlen.
 
     Returns:
         If a matching shortest path is found, it is returned as a list of Line objects.

--- a/openlr_dereferencer/decoding/candidates.py
+++ b/openlr_dereferencer/decoding/candidates.py
@@ -11,55 +11,32 @@ from .candidate import Candidate
 from .scoring import score_lrp_candidate
 from .tools import LRDecodeError, coords, project
 from .routes import Route
+from .configuration import Config
 
-#: Tolerable relative DNP deviation of a path
-#:
-#: A path may deviate from the DNP by this relative value plus TOLERATED_DNP_DEV in order to be
-#: considered. The value here is relative to the expected distance to next point.
-MAX_DNP_DEVIATION = 0.3
-
-#: Additional buffer to the range of allowed path distance
-#:
-#: In order to be considered, a path must not deviate from the DNP value by more than
-#: MAX_DNP_DEVIATION (relative value) plus TOLERATED_DNP_DEV. This value is in meters.
-TOLERATED_DNP_DEV = 30
-
-#: A filter for candidates with insufficient score. Candidates below this score are not considered
-MIN_SCORE = 0.3
-
-TOLERATED_LFRC = {frc:frc for frc in FRC}
-
-#: Partial candidate line threshold, measured in meters
-#:
-#: To find candidates, the LRP coordinates are projected against any line in the local area.
-#: If the distance from the starting point is greater than this threshold, the partial line
-#: beginning at the projection point is considered to be the candidate.
-CANDIDATE_THRESHOLD = 20
-
-def make_candidates(lrp: LocationReferencePoint, line: Line, radius: float, is_last_lrp: bool) -> Iterable[Candidate]:
+def make_candidates(lrp: LocationReferencePoint, line: Line, config: Config, is_last_lrp: bool) -> Iterable[Candidate]:
     "Return zero or more LRP candidates based on the given line"
     dist = line.length
     reloff = project(line.geometry, coords(lrp))
     # Snap to the relevant end of the line
-    if not is_last_lrp and reloff * dist <= CANDIDATE_THRESHOLD:
+    if not is_last_lrp and reloff * dist <= config.candidate_threshold:
         reloff = 0.0
-    if is_last_lrp and (1 - reloff) * dist <= CANDIDATE_THRESHOLD:
+    if is_last_lrp and (1 - reloff) * dist <= config.candidate_threshold:
         reloff = 1.0
     # Drop candidate if there is no partial line left
     if is_last_lrp and reloff == 0.0 or not is_last_lrp and reloff == 1.0:
         return
     candidate = Candidate(line, reloff)
-    candidate.score = score_lrp_candidate(lrp, candidate, radius, is_last_lrp)
-    if candidate.score >= MIN_SCORE:
+    candidate.score = score_lrp_candidate(lrp, candidate, config, is_last_lrp)
+    if candidate.score >= config.min_score:
         yield candidate
 
 def nominate_candidates(
-    lrp: LocationReferencePoint, reader: MapReader, radius: float, is_last_lrp: bool
+    lrp: LocationReferencePoint, reader: MapReader, config: Config, is_last_lrp: bool
 ) -> Iterable[Candidate]:
     "Returns a list of candidate lines for the LRP along with their score."
-    debug(f"Finding candidates for LRP {lrp} at {coords(lrp)} in radius {radius}")
-    for line in reader.find_lines_close_to(coords(lrp), radius):
-        yield from make_candidates(lrp, line, radius, is_last_lrp)
+    debug(f"Finding candidates for LRP {lrp} at {coords(lrp)} in radius {config.search_radius}")
+    for line in reader.find_lines_close_to(coords(lrp), config.search_radius):
+        yield from make_candidates(lrp, line, config, is_last_lrp)
 
 def get_candidate_route(
     map_reader: MapReader, c1: Candidate, c2: Candidate, lfrc: FRC, last_lrp: bool, maxlen: float
@@ -104,7 +81,7 @@ def match_tail(
     candidates: List[Candidate],
     tail: List[LocationReferencePoint],
     reader: MapReader,
-    radius: float,
+    config: Config,
     observer: Optional[DecoderObserver]
 ) -> List[Route]:
 
@@ -118,14 +95,14 @@ def match_tail(
     If not, a `LRDecodeError` exception is raised."""
     last_lrp = len(tail) == 1
     # The accepted distance to next point. This helps to save computations and filter bad paths
-    minlen = (1 - MAX_DNP_DEVIATION) * current.dnp - TOLERATED_DNP_DEV
-    maxlen = (1 + MAX_DNP_DEVIATION) * current.dnp + TOLERATED_DNP_DEV
-    lfrc = TOLERATED_LFRC[current.lfrcnp]
+    minlen = (1 - config.max_dnp_deviation) * current.dnp - config.tolerated_dnp_dev
+    maxlen = (1 + config.max_dnp_deviation) * current.dnp + config.tolerated_dnp_dev
+    lfrc = config.tolerated_lfrc[current.lfrcnp]
 
     # Generate all pairs of candidates for the first two lrps
     next_lrp = tail[0]
 
-    next_candidates = list(nominate_candidates(next_lrp, reader, radius, last_lrp))
+    next_candidates = list(nominate_candidates(next_lrp, reader, config, last_lrp))
 
     if observer is not None:
         observer.on_candidates_found(next_lrp, next_candidates)
@@ -163,8 +140,8 @@ def match_tail(
 
         # If not last LRP, match also the rest of tail
         if len(tail) == 2:
-            c2.score = score_lrp_candidate(next_lrp, c2, radius, True)
+            c2.score = score_lrp_candidate(next_lrp, c2, config, True)
 
-        return [route] + match_tail(next_lrp, [c2], tail[1:], reader, radius, observer)
+        return [route] + match_tail(next_lrp, [c2], tail[1:], reader, config, observer)
 
     raise LRDecodeError("Decoding was unsuccessful: No candidates left or available.")

--- a/openlr_dereferencer/decoding/configuration.py
+++ b/openlr_dereferencer/decoding/configuration.py
@@ -15,20 +15,30 @@ DEFAULT_FOW_STAND_IN_SCORE = [
 ]
 
 class Config(NamedTuple):
-    "A config object provides all settings that influenec the decoder's behaviour"
+    """A config object that provides all settings that influences the decoder's behaviour
+    
+    Customize the values where the default won't fit you:
+
+    .. code-block:: python
+
+        myconfig = Config(min_score=0.9, search_radius=10)
+    """
+
     #: Configures the default radius to search for map objects around an LRP. This value is in meters.
     search_radius: float = 100.0
     #: Tolerable relative DNP deviation of a path
     #:
-    #: A path may deviate from the DNP by this relative value plus TOLERATED_DNP_DEV in order to be
-    #: considered. The value here is relative to the expected distance to next point.
+    #: A path between consecutive LRPs may deviate from the DNP by this relative value plus
+    #: :py:attr:`~tolerated_dnp_dev` in order to be considered. The value here is relative
+    #: to the expected distance to next point.
     max_dnp_deviation: float = 0.3
     #: Additional buffer to the range of allowed path distance
     #:
     #: In order to be considered, a path must not deviate from the DNP value by more than
-    #: MAX_DNP_DEVIATION (relative value) plus TOLERATED_DNP_DEV. This value is in meters.
+    #: :py:attr:`~max_dnp_deviation` (relative value) plus :py:attr:`~tolerated_dnp_dev`. This value is in meters.
     tolerated_dnp_dev: int = 30
-    #: A filter for candidates with insufficient score. Candidates below this score are not considered
+    #: A filter for candidates with insufficient score. Candidates below this score are not considered.
+    #: As this value is a score, it is in the range of [0.0, 1.0].
     min_score: float = 0.3
     #: For every LFRCNP possibly present in an LRP, this defines
     #: what lowest FRC in a considered route is acceptable
@@ -37,7 +47,8 @@ class Config(NamedTuple):
     #:
     #: To find candidates, the LRP coordinates are projected against any line in the local area.
     #: If the distance from the starting point is greater than this threshold, the partial line
-    #: beginning at the projection point is considered to be the candidate.
+    #: beginning at the projection point is considered to be the candidate. Else, the candidate
+    #: snaps onto the startng point (or ending point, when it is the last LRP)
     candidate_threshold = 20
     #: Defines the weight the FOW score has on the overall score of a candidate.
     fow_weight: float = 1 / 4
@@ -49,10 +60,10 @@ class Config(NamedTuple):
     bear_weight: float = 1 / 4
     #: When comparing an LRP FOW with a candidate's FOW, this matrix defines
     #: how well the candidate's FOW fits as replacement for the expected value.
-    #: The usage is `FOW_SCORING[lrp's fow][candidate's fow]`.
+    #: The usage is `fow_standin_score[lrp's fow][candidate's fow]`.
     #: It returns the score.
     fow_standin_score: List[List[float]] = DEFAULT_FOW_STAND_IN_SCORE
-    #: The bearing angle is computed along this distance on given line. Given in meters.
+    #: The bearing angle is computed along this distance on a given line. Given in meters.
     bear_dist: int = 20
 
 DEFAULT_CONFIG = Config()

--- a/openlr_dereferencer/decoding/configuration.py
+++ b/openlr_dereferencer/decoding/configuration.py
@@ -72,7 +72,7 @@ class Config(NamedTuple):
 
 DEFAULT_CONFIG = Config()
 
-def load(source: Union[str, TextIOBase, dict]) -> Config:
+def load_config(source: Union[str, TextIOBase, dict]) -> Config:
     """Load config from a source
     
     Args:
@@ -113,7 +113,7 @@ def load(source: Union[str, TextIOBase, dict]) -> Config:
     )
 
 
-def save(config: Config, dest: Union[str, TextIOBase, type(None)] = None) -> Optional[dict]:
+def save_config(config: Config, dest: Union[str, TextIOBase, type(None)] = None) -> Optional[dict]:
     """Saves a config to a file or a dictionary
     
     Args:
@@ -125,6 +125,6 @@ def save(config: Config, dest: Union[str, TextIOBase, type(None)] = None) -> Opt
         return config._asdict()
     if isinstance(dest, str):
         with open(dest, "w") as fp:
-            fp.write(dumps(save(config)))
+            save_config(fp)
     if isinstance(dest, TextIOBase):
-        dest.write(dumps(save(config)))
+        dest.write(dumps(save_config(config)))

--- a/openlr_dereferencer/decoding/configuration.py
+++ b/openlr_dereferencer/decoding/configuration.py
@@ -125,6 +125,6 @@ def save_config(config: Config, dest: Union[str, TextIOBase, type(None)] = None)
         return config._asdict()
     if isinstance(dest, str):
         with open(dest, "w") as fp:
-            save_config(fp)
+            save_config(config, fp)
     if isinstance(dest, TextIOBase):
         dest.write(dumps(save_config(config)))

--- a/openlr_dereferencer/decoding/configuration.py
+++ b/openlr_dereferencer/decoding/configuration.py
@@ -1,0 +1,58 @@
+from typing import NamedTuple, List, Dict
+from openlr import FRC, FOW
+
+#: The default value for the `fow_standin_score` config option.
+#: The values are adopted from the openlr Java implementation.
+DEFAULT_FOW_STAND_IN_SCORE = [
+    [0.50, 0.50, 0.50, 0.50, 0.50, 0.50, 0.50, 0.5],  # Undefined FOW
+    [0.50, 1.00, 0.75, 0.00, 0.00, 0.00, 0.00, 0.0],  # Motorway
+    [0.50, 0.75, 1.00, 0.75, 0.50, 0.00, 0.00, 0.0],  # Multiple carriage way
+    [0.50, 0.00, 0.75, 1.00, 0.50, 0.50, 0.00, 0.0],  # Single carriage way
+    [0.50, 0.00, 0.50, 0.50, 1.00, 0.50, 0.00, 0.0],  # Roundabout
+    [0.50, 0.00, 0.00, 0.50, 0.50, 1.00, 0.00, 0.0],  # Traffic quare
+    [0.50, 0.00, 0.00, 0.00, 0.00, 0.00, 1.00, 0.0],  # Sliproad
+    [0.50, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 1.0],  # Other FOW
+]
+
+class Config(NamedTuple):
+    "A config object provides all settings that influenec the decoder's behaviour"
+    #: Configures the default radius to search for map objects around an LRP. This value is in meters.
+    search_radius: float = 100.0
+    #: Tolerable relative DNP deviation of a path
+    #:
+    #: A path may deviate from the DNP by this relative value plus TOLERATED_DNP_DEV in order to be
+    #: considered. The value here is relative to the expected distance to next point.
+    max_dnp_deviation: float = 0.3
+    #: Additional buffer to the range of allowed path distance
+    #:
+    #: In order to be considered, a path must not deviate from the DNP value by more than
+    #: MAX_DNP_DEVIATION (relative value) plus TOLERATED_DNP_DEV. This value is in meters.
+    tolerated_dnp_dev: int = 30
+    #: A filter for candidates with insufficient score. Candidates below this score are not considered
+    min_score: float = 0.3
+    #: For every LFRCNP possibly present in an LRP, this defines
+    #: what lowest FRC in a considered route is acceptable
+    tolerated_lfrc: Dict[FRC, FRC] = {frc:frc for frc in FRC}
+    #: Partial candidate line threshold, measured in meters
+    #:
+    #: To find candidates, the LRP coordinates are projected against any line in the local area.
+    #: If the distance from the starting point is greater than this threshold, the partial line
+    #: beginning at the projection point is considered to be the candidate.
+    candidate_threshold = 20
+    #: Defines the weight the FOW score has on the overall score of a candidate.
+    fow_weight: float = 1 / 4
+    #: Defines the weight the FRC score has on the overall score of a candidate.
+    frc_weight: float = 1 / 4
+    #: Defines the weight the coordinate difference has on the overall score of a candidate.
+    geo_weight: float = 1 / 4
+    #: Defines the weight the bearing score has on the overall score of a candidate.
+    bear_weight: float = 1 / 4
+    #: When comparing an LRP FOW with a candidate's FOW, this matrix defines
+    #: how well the candidate's FOW fits as replacement for the expected value.
+    #: The usage is `FOW_SCORING[lrp's fow][candidate's fow]`.
+    #: It returns the score.
+    fow_standin_score: List[List[float]] = DEFAULT_FOW_STAND_IN_SCORE
+    #: The bearing angle is computed along this distance on given line. Given in meters.
+    bear_dist: int = 20
+
+DEFAULT_CONFIG = Config()

--- a/openlr_dereferencer/decoding/configuration.py
+++ b/openlr_dereferencer/decoding/configuration.py
@@ -98,7 +98,10 @@ def load(source: Union[str, TextIOBase, dict]) -> Config:
             opened_source['max_dnp_deviation'],
             opened_source['tolerated_dnp_dev'],
             opened_source['min_score'],
-            opened_source['tolerated_lfrc'],
+            {
+                FRC(int(key)): FRC(value)
+                for (key, value) in opened_source['tolerated_lfrc'].items() 
+            },
             opened_source['candidate_threshold'],
             opened_source['fow_weight'],
             opened_source['frc_weight'],

--- a/openlr_dereferencer/decoding/line_decoding.py
+++ b/openlr_dereferencer/decoding/line_decoding.py
@@ -7,25 +7,26 @@ from ..observer import DecoderObserver
 from .candidates import nominate_candidates, match_tail
 from .line_location import build_line_location, LineLocation
 from .routes import Route
+from .configuration import Config
 
 def dereference_path(
-    lrps: List[LocationReferencePoint], reader: MapReader, radius: float, observer: Optional[DecoderObserver]
+    lrps: List[LocationReferencePoint], reader: MapReader, config: Config, observer: Optional[DecoderObserver]
 ) -> List[Route]:
     "Decode the location reference path, without considering any offsets"
     first_lrp = lrps[0]
-    first_candidates = list(nominate_candidates(first_lrp, reader, radius, False))
+    first_candidates = list(nominate_candidates(first_lrp, reader, config, False))
 
     if observer is not None:
         observer.on_candidates_found(first_lrp, first_candidates)
 
-    linelocationpath = match_tail(first_lrp, first_candidates, lrps[1:], reader, radius, observer)
+    linelocationpath = match_tail(first_lrp, first_candidates, lrps[1:], reader, config, observer)
     return linelocationpath
 
 
-def decode_line(reference: LineLocationRef, reader: MapReader, radius: float, observer: Optional[DecoderObserver]) -> LineLocation:
+def decode_line(reference: LineLocationRef, reader: MapReader, config: Config, observer: Optional[DecoderObserver]) -> LineLocation:
     """Decodes an openLR line location reference
 
     Candidates are searched in a radius of `radius` meters around an LRP."""
-    parts = dereference_path(reference.points, reader, radius, observer)
+    parts = dereference_path(reference.points, reader, config, observer)
     return build_line_location(parts, reference)
 

--- a/openlr_dereferencer/decoding/point_locations.py
+++ b/openlr_dereferencer/decoding/point_locations.py
@@ -14,6 +14,7 @@ from ..observer import DecoderObserver
 from ..maps.wgs84 import project_along_path
 from .line_decoding import dereference_path
 from .line_location import get_lines, Route, combine_routes
+from .configuration import Config
 from . import LRDecodeError
 
 
@@ -53,10 +54,10 @@ def point_along_linelocation(route: Route, length: float) -> Tuple[Line, float]:
 
 
 def decode_pointalongline(
-    reference: PointAlongLineLocation, reader: MapReader, radius: float, observer: Optional[DecoderObserver]
+    reference: PointAlongLineLocation, reader: MapReader, config: Config, observer: Optional[DecoderObserver]
 ) -> PointAlongLine:
     "Decodes a point along line location reference"
-    path = combine_routes(dereference_path(reference.points, reader, radius, observer))
+    path = combine_routes(dereference_path(reference.points, reader, config, observer))
     absolute_offset = path.length() * reference.poffs
     line_object, line_offset = point_along_linelocation(path, absolute_offset)
     return PointAlongLine(line_object, line_offset, reference.sideOfRoad, reference.orientation)
@@ -76,10 +77,10 @@ class PoiWithAccessPoint(NamedTuple):
 
 
 def decode_poi_with_accesspoint(
-    reference: PoiWithAccessPointLocation, reader: MapReader, radius: float, observer: Optional[DecoderObserver]
+    reference: PoiWithAccessPointLocation, reader: MapReader, config: Config, observer: Optional[DecoderObserver]
     ) -> PoiWithAccessPoint:
     "Decodes a point along line location reference into a Coordinates tuple"
-    path = combine_routes(dereference_path(reference.points, reader, radius, observer))
+    path = combine_routes(dereference_path(reference.points, reader, config, observer))
     absolute_offset = path_length(get_lines([path])) * reference.poffs
     line, line_offset = point_along_linelocation(path, absolute_offset)
     return PoiWithAccessPoint(

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         'openlr_dereferencer.maps',
         'openlr_dereferencer.maps.a_star',
         'openlr_dereferencer.decoding',
+        'openlr_dereferencer.observer',
         'openlr_dereferencer'],
     install_requires=["openlr==1.0.0", "geographiclib", "shapely"],
     test_suite="tests",

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -19,6 +19,8 @@ from openlr_dereferencer.maps.wgs84 import distance, bearing
 
 from .example_mapformat import setup_testdb, remove_db_file
 
+from openlr_dereferencer import load_config, save_config, DEFAULT_CONFIG
+
 class DummyNode():
     "Fake Node class for unit testing"
     def __init__(self, coord: Coordinates):
@@ -374,6 +376,14 @@ class DecodingTests(unittest.TestCase):
         decode(reference, self.reader, observer=observer)
         self.assertTrue(observer.candidates)
         self.assertListEqual([route.success for route in observer.attempted_routes], [True])
+
+    def test_load_saved_config(self):
+        "Save and load a Config object"
+        filename = "test-config.json"
+        save_config(DEFAULT_CONFIG, filename)
+        config = load_config(filename)
+        self.assertDictEqual(config.tolerated_lfrc, DEFAULT_CONFIG.tolerated_lfrc)
+        self.assertEqual(config.bear_dist, DEFAULT_CONFIG.bear_dist)
 
     def tearDown(self):
         self.reader.connection.close()


### PR DESCRIPTION
This introduces the [Config](https://openlr-dereferencer-python.readthedocs.io/en/configuration-object/openlr_dereferencer.decoding.html#openlr_dereferencer.decoding.configuration.Config) object, which can be passed to `decode`.

- [X] Config object
- [X] Replace all configuration 'constants'
- [x] Load from file / serialize+deserialize
- [x] Update docs that refer to the removed 'constants'