### PR TITLE
Running the test in-memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,9 +36,6 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
-test-config.json
-db.sqlite
-db.sqlite-journal
 
 # Sphinx documentation
 docs/_build/

--- a/tests/example_mapformat.py
+++ b/tests/example_mapformat.py
@@ -51,15 +51,22 @@ INSERT INTO lines (startnode, endnode, frc, fow, path) VALUES
     (14, 5, 1, 3, ST_GeomFromText("LINESTRING(13.41 52.5245, 13.4125 52.521, 13.4175 52.521)", {SRID})),
     (14, 13, 3, 3, ST_GeomFromText("LINESTRING(13.41 52.5245, 13.4123 52.52, 13.42 52.52, 13.425 52.521, 13.429 52.523)", {SRID}));
 """
-
-def setup_testdb(db_file: str):
-    "Creates a sqlite DB with all the test data"
-    conn = sqlite3.connect(db_file)
+def _setup_connection(conn):
     conn.enable_load_extension(True)
     conn.load_extension('mod_spatialite')
     cur = conn.cursor()
     cur.executescript(INIT_SQL)
+
+def setup_testdb(db_file: str):
+    "Creates a sqlite DB with all the test data"
+    conn = sqlite3.connect(db_file)
+    _setup_connection(conn)
     conn.close()
+
+def setup_testdb_in_memory():
+    conn = sqlite3.connect(":memory:")
+    _setup_connection(conn)
+    return conn
 
 def remove_db_file(db_file: str):
     "Removes the sqlite DB file, and does not raise when nonexistent"

--- a/tests/example_mapformat.py
+++ b/tests/example_mapformat.py
@@ -64,6 +64,7 @@ def setup_testdb(db_file: str):
     conn.close()
 
 def setup_testdb_in_memory():
+    "Creates a sqlite DB and returns a connection for quicker tests"
     conn = sqlite3.connect(":memory:")
     _setup_connection(conn)
     return conn

--- a/tests/test_a_star.py
+++ b/tests/test_a_star.py
@@ -5,16 +5,14 @@ import unittest
 from openlr_dereferencer.maps import shortest_path
 from openlr_dereferencer.example_sqlite_map import ExampleMapReader
 
-from .example_mapformat import setup_testdb, remove_db_file
+from .example_mapformat import setup_testdb_in_memory, remove_db_file
 
 class AStarTests(unittest.TestCase):
     "Tests the A* module"
-    db = 'db.sqlite'
 
     def setUp(self):
-        remove_db_file(self.db)
-        setup_testdb(self.db)
-        self.reader = ExampleMapReader(self.db)
+        self.reader = ExampleMapReader(":memory:")
+        self.reader.connection = setup_testdb_in_memory()
 
     def test_shortest_path_same_node(self):
         "Shortest path between a node and itself is empty"
@@ -58,4 +56,3 @@ class AStarTests(unittest.TestCase):
 
     def tearDown(self):
         self.reader.connection.close()
-        remove_db_file(self.db)

--- a/tests/test_sqlite_map.py
+++ b/tests/test_sqlite_map.py
@@ -10,7 +10,7 @@ from openlr_dereferencer.example_sqlite_map import (
     ExampleMapReader, Line, ExampleMapError, Node
 )
 
-from .example_mapformat import setup_testdb,setup_testdb_in_memory, remove_db_file
+from .example_mapformat import setup_testdb_in_memory, remove_db_file
 
 class SQLiteMapTest(unittest.TestCase):
     "A few unit tests for the example sqlite mapformat"

--- a/tests/test_sqlite_map.py
+++ b/tests/test_sqlite_map.py
@@ -10,16 +10,14 @@ from openlr_dereferencer.example_sqlite_map import (
     ExampleMapReader, Line, ExampleMapError, Node
 )
 
-from .example_mapformat import setup_testdb, remove_db_file
+from .example_mapformat import setup_testdb,setup_testdb_in_memory, remove_db_file
 
 class SQLiteMapTest(unittest.TestCase):
     "A few unit tests for the example sqlite mapformat"
-    db = 'db.sqlite'
 
     def setUp(self):
-        remove_db_file(self.db)
-        setup_testdb(self.db)
-        self.reader = ExampleMapReader(self.db)
+        self.reader = ExampleMapReader(":memory:")
+        self.reader.connection = setup_testdb_in_memory()
 
     def test_line_invalid_id_type(self):
         "Check if an invalid line id raises an error"
@@ -122,4 +120,3 @@ class SQLiteMapTest(unittest.TestCase):
 
     def tearDown(self):
         self.reader.connection.close()
-        remove_db_file(self.db)


### PR DESCRIPTION
SQLite and config file tests are moved to memory. Very drastic speed improvement like 85% time reduction!

The full tests takes only 3 seconds per environment meaning `tox` command is taking 76 seconds less with this change.