### PR TITLE
Replaced f-strings in logging calls 

### DIFF
--- a/openlr_dereferencer/decoding/candidate_functions.py
+++ b/openlr_dereferencer/decoding/candidate_functions.py
@@ -56,8 +56,7 @@ def make_candidates(
     bearing = compute_bearing(lrp, candidate, is_last_lrp, config.bear_dist)
     bear_diff = angle_difference(bearing, lrp.bear)
     if abs(bear_diff) > config.max_bear_deviation:
-        debug(f"Not considering {candidate} because the bearing difference is {bear_diff} °.",
-              f"bear: {bearing}. lrp bear: {lrp.bear}")
+        debug("Not considering %s because the bearing difference is %.02f°. (bear: %.02f. lrp bear: %.02f)", candidate, bear_diff, bearing, lrp.bear)
         return
     candidate.score = score_lrp_candidate(lrp, candidate, config, is_last_lrp)
     if candidate.score >= config.min_score:
@@ -68,7 +67,7 @@ def nominate_candidates(
         lrp: LocationReferencePoint, reader: MapReader, config: Config, is_last_lrp: bool
 ) -> Iterable[Candidate]:
     "Yields candidate lines for the LRP along with their score."
-    debug(f"Finding candidates for LRP {lrp} at {coords(lrp)} in radius {config.search_radius}")
+    debug("Finding candidates for LRP %s at %s in radius %.02f", lrp, coords(lrp), config.search_radius)
     for line in reader.find_lines_close_to(coords(lrp), config.search_radius):
         yield from make_candidates(lrp, line, config, is_last_lrp)
 
@@ -95,14 +94,14 @@ def get_candidate_route(start: Candidate, dest: Candidate, lfrc: FRC, maxlen: fl
         The returned path excludes the lines the candidate points are on.
         If there is no matching path found, None is returned.
     """
-    debug(f"Try to find path between {start, dest}")
+    debug("Try to find path between %s,%s",start, dest)
     if start.line.line_id == dest.line.line_id:
         return Route(start, [], dest)
-    debug(f"Finding path between nodes {start.line.end_node.node_id, dest.line.start_node.node_id}")
+    debug("Finding path between nodes %d,%d",start.line.end_node.node_id, dest.line.start_node.node_id)
     linefilter = lambda line: line.frc <= lfrc
     try:
         path = shortest_path(start.line.end_node, dest.line.start_node, linefilter, maxlen=maxlen)
-        debug(f"Returning {path}")
+        debug("Returning %s", path)
         return Route(start, path, dest)
     except LRPathNotFoundError:
         debug(f"No path found between these nodes")
@@ -224,7 +223,7 @@ def handleCandidatePair(
     if observer is not None:
         observer.on_route_success(current, next_lrp, source, dest, route)
 
-    debug(f"DNP should be {current.dnp} m, is {length} m.")
+    debug("DNP should be %.02fm, is %.02fm.", current.dnp, length)
     # If the path does not match DNP, continue with the next candidate pair
     if length < minlen or length > maxlen:
         debug("Shortest path deviation from DNP is too large")

--- a/openlr_dereferencer/decoding/candidate_functions.py
+++ b/openlr_dereferencer/decoding/candidate_functions.py
@@ -104,7 +104,7 @@ def get_candidate_route(start: Candidate, dest: Candidate, lfrc: FRC, maxlen: fl
         debug("Returning %s", path)
         return Route(start, path, dest)
     except LRPathNotFoundError:
-        debug(f"No path found between these nodes")
+        debug("No path found between these nodes")
         return None
 
 
@@ -229,6 +229,6 @@ def handleCandidatePair(
         debug("Shortest path deviation from DNP is too large")
         return None
 
-    debug(f"Taking route {route}.")
+    debug("Taking route %s.", route)
 
     return route

--- a/openlr_dereferencer/decoding/path_math.py
+++ b/openlr_dereferencer/decoding/path_math.py
@@ -14,23 +14,21 @@ from ..maps.wgs84 import interpolate, bearing, line_string_length
 
 def remove_offsets(path: Route, p_off: float, n_off: float) -> Route:
     """Remove start+end offsets, measured in meters, from a route and return the result"""
-    debug(f"Will consider positive offset = {p_off} m and negative offset {n_off} m.")
+    debug("Will consider positive offset = %.02fm and negative offset %.02fm.", p_off, n_off)
     lines = path.lines
-    debug(f"This routes consists of {lines} and is {path.length()} m long.")
+    debug("This route consists of %s and is %.02fm long.", lines, path.length())
     # Remove positive offset
-    debug(f"first line's offset is {path.absolute_start_offset}")
+    debug("first line's offset is %.02f",path.absolute_start_offset)
     remaining_poff = p_off + path.absolute_start_offset
     while remaining_poff >= lines[0].length:
-        debug(f"Remaining positive offset {remaining_poff} is greater than "
-              f"the first line. Removing it.")
+        debug("Remaining positive offset %.02f is greater than the first line. Removing it.", remaining_poff)
         remaining_poff -= lines.pop(0).length
         if not lines:
             raise LRDecodeError("Offset is bigger than line location path")
     # Remove negative offset
     remaining_noff = n_off + path.absolute_end_offset
     while remaining_noff >= lines[-1].length:
-        debug(f"Remaining negative offset {remaining_noff} is greater than "
-              f"the last line. Removing it.")
+        debug("Remaining negative offset %.02f is greater than the last line. Removing it.", remaining_noff)
         remaining_noff -= lines.pop().length
         if not lines:
             raise LRDecodeError("Offset is bigger than line location path")

--- a/openlr_dereferencer/decoding/scoring.py
+++ b/openlr_dereferencer/decoding/scoring.py
@@ -21,7 +21,7 @@ def score_geolocation(wanted: LocationReferencePoint, actual: PointOnLine, radiu
     """Scores the geolocation of a candidate.
 
     A distance of `radius` or more will result in a 0.0 score."""
-    debug(f"Candidate coords are {actual.position()}")
+    debug("Candidate coords are %s", actual.position())
     dist = distance(coords(wanted), actual.position())
     if dist < radius:
         return 1.0 - dist / radius
@@ -118,13 +118,13 @@ def score_lrp_candidate(
     """Scores the candidate (line) for the LRP.
 
     This is the average of fow, frc, geo and bearing score."""
-    debug(f"scoring {candidate} with config {config}")
+    debug("scoring %s with config %s", candidate, config)
     geo_score = config.geo_weight * score_geolocation(wanted, candidate, config.search_radius)
     fow_score = config.fow_weight * config.fow_standin_score[wanted.fow][candidate.line.fow]
     frc_score = config.frc_weight * score_frc(wanted.frc, candidate.line.frc)
     bear_score = score_bearing(wanted, candidate, is_last_lrp, config.bear_dist)
     bear_score *= config.bear_weight
     score = fow_score + frc_score + geo_score + bear_score
-    debug(f"Score: geo {geo_score} + fow {fow_score} + frc {frc_score} "
-          f"+ bear {bear_score} = {score}")
+    debug("Score: geo(%.02f) + fow(%.02f) + frc(%.02f) + bear(%.02f) = %.02f", geo_score, fow_score, frc_score, bear_score, score
+    )
     return score


### PR DESCRIPTION
Replaced f-strings in logging statements with printf-style formatting to eliminate unnecessary string interpolation overhead when not debugging.