### PR TITLE
Specify correct whitepaper chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 This is a Python package for decoding OpenLR™ location references on target maps.
 
-It implements [Chapter H – Decoder](https://www.openlr-association.com/fileadmin/user_upload/openlr-whitepaper_v1.5.pdf#page=97) in the OpenLR whitepaper, except "Step 1 – decode physical data".
+It implements [Chapter G – Decoder](https://www.openlr-association.com/fileadmin/user_upload/openlr-whitepaper_v1.5.pdf#page=97) in the OpenLR whitepaper, except "Step 1 – decode physical data".
 
 Its purpose is to give insights into the map-matching process.
 


### PR DESCRIPTION
Just noticed the README references the whitepaper by a wrong letter – it should be G instead of H.

The page link is still correct, though.