### PR TITLE
TTIRI-561 Fix division by zero error

### DIFF
--- a/openlr_dereferencer/decoding/candidate_functions.py
+++ b/openlr_dereferencer/decoding/candidate_functions.py
@@ -19,6 +19,10 @@ def make_candidates(
     lrp: LocationReferencePoint, line: Line, config: Config, is_last_lrp: bool
 ) -> Iterable[Candidate]:
     "Yields zero or more LRP candidates based on the given line"
+    # When the line is of length zero, we expect that also the adjacent lines are considered as candidates, hence
+    # we don't need to project one the point that is the degenerated line.
+    if line.geometry.length == 0:
+        return
     point_on_line = project(line, coords(lrp))
     reloff = point_on_line.relative_offset
     # In case the LRP is not the last LRP
@@ -29,7 +33,7 @@ def make_candidates(
             reloff = 0.0
         # If the projection onto the line is close to the END of the line,
         # discard the point since we expect that the start of
-        # the an adjacent line will be considered as candidate and that would be the better candidate.
+        # an adjacent line will be considered as candidate and that would be the better candidate.
         else:
             if abs(point_on_line.distance_to_end()) <= config.candidate_threshold and is_valid_node(line.end_node):
                 return

--- a/openlr_dereferencer/decoding/candidate_functions.py
+++ b/openlr_dereferencer/decoding/candidate_functions.py
@@ -20,7 +20,7 @@ def make_candidates(
 ) -> Iterable[Candidate]:
     "Yields zero or more LRP candidates based on the given line"
     # When the line is of length zero, we expect that also the adjacent lines are considered as candidates, hence
-    # we don't need to project one the point that is the degenerated line.
+    # we don't need to project on the point that is the degenerated line.
     if line.geometry.length == 0:
         return
     point_on_line = project(line, coords(lrp))

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -11,7 +11,7 @@ from openlr import Coordinates, FRC, FOW, LineLocationReference, LocationReferen
 
 from openlr_dereferencer import decode, Config
 from openlr_dereferencer.decoding import PointAlongLine, LineLocation, LRDecodeError, PoiWithAccessPoint
-from openlr_dereferencer.decoding.candidate_functions import nominate_candidates
+from openlr_dereferencer.decoding.candidate_functions import nominate_candidates, make_candidates
 from openlr_dereferencer.decoding.scoring import score_geolocation, score_frc, \
     score_bearing, score_angle_difference
 from openlr_dereferencer.decoding.routes import PointOnLine, Route
@@ -161,6 +161,13 @@ class DecodingTests(unittest.TestCase):
         self.reader = ExampleMapReader(":memory:")
         self.reader.connection = setup_testdb_in_memory()
         self.config = Config()
+
+    def test_make_candidates_with_zero_length_line(self):
+        lrp = LocationReferencePoint(0.0, 0.0, None, None, None, None, None)
+        node1 = DummyNode(Coordinates(0.0, 0.0))
+        node2 = DummyNode(Coordinates(0.0, 0.0))
+        line = DummyLine(0, node1, node2)
+        self.assertListEqual(list(make_candidates(lrp, line, self.config, False)), [])
 
     def test_geoscore_1(self):
         "Test scoring an excactly matching LRP candidate line"


### PR DESCRIPTION
Lines that had a length zero linestring as geometry were causing division by zero errors when trying to project a point onto them. We don't need to consider these lines as candidates as their adjacent lines are also considered and so is the point that is the degenerated line. Observe, there is a difference between the length of the line and the length of its geometry. The first might be positive even though the second is 0, probably due to rounding issues while converting maps.