### PR TITLE
Changes from STL

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a Python package for decoding OpenLR™ location references on target ma
 
 It implements [Chapter G – Decoder](https://www.openlr-association.com/fileadmin/user_upload/openlr-whitepaper_v1.5.pdf#page=97) in the OpenLR whitepaper, except "Step 1 – decode physical data".
 
-Its purpose is to give insights into the map-matching process.
+Its purpose is to give insights into the map-matching process. Test!
 
 ## Dependencies
 - Python ≥ 3.6

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a Python package for decoding OpenLR™ location references on target ma
 
 It implements [Chapter G – Decoder](https://www.openlr-association.com/fileadmin/user_upload/openlr-whitepaper_v1.5.pdf#page=97) in the OpenLR whitepaper, except "Step 1 – decode physical data".
 
-Its purpose is to give insights into the map-matching process. Test!
+Its purpose is to give insights into the map-matching process.
 
 ## Dependencies
 - Python ≥ 3.6

--- a/openlr_dereferencer/decoding/__init__.py
+++ b/openlr_dereferencer/decoding/__init__.py
@@ -22,20 +22,19 @@ from .point_locations import (
 )
 from .configuration import Config, DEFAULT_CONFIG, load_config, save_config
 
-LR = TypeVar("LocationReference",
-             LineLocationReference,
-             PointAlongLineLocationReference,
-             PoiWithAccessPointLocationReference,
-             GeoCoordinateLocationReference)
+LR = TypeVar(
+    "LocationReference",
+    LineLocationReference,
+    PointAlongLineLocationReference,
+    PoiWithAccessPointLocationReference,
+    GeoCoordinateLocationReference,
+)
 
 MapObjects = TypeVar("MapObjects", LineLocation, Coordinates, PointAlongLine)
 
 
 def decode(
-        reference: LR,
-        reader: MapReader,
-        observer: Optional[DecoderObserver] = None,
-        config: Config = DEFAULT_CONFIG
+    reference: LR, reader: MapReader, observer: Optional[DecoderObserver] = None, config: Config = DEFAULT_CONFIG
 ) -> MapObjects:
     """Translates an openLocationReference into a real location on your map.
 

--- a/openlr_dereferencer/decoding/configuration.py
+++ b/openlr_dereferencer/decoding/configuration.py
@@ -48,7 +48,7 @@ class Config(NamedTuple):
     min_score: float = 0.3
     #: For every LFRCNP possibly present in an LRP, this defines
     #: what lowest FRC in a considered route is acceptable
-    tolerated_lfrc: Dict[FRC, FRC] = {frc: frc for frc in FRC}
+    tolerated_lfrc: Dict[FRC, FRC] = {frc: frc if frc < 4 else 6 for frc in FRC}
     #: Partial candidate line threshold, measured in meters
     #:
     #: To find candidates, the LRP coordinates are projected against any line in the local area.
@@ -56,6 +56,7 @@ class Config(NamedTuple):
     #: beginning at the projection point is considered to be the candidate. Else, the candidate
     #: snaps onto the starting point (or ending point, when it is the last LRP)
     candidate_threshold: int = 20
+    rel_candidate_threshold: float = 1.0
     #: Defines a threshold for the bearing difference. Candidates differing too much from
     #: the LRP's bearing value are pre-filtered.
     max_bear_deviation: float = 45.0
@@ -74,6 +75,11 @@ class Config(NamedTuple):
     fow_standin_score: List[List[float]] = DEFAULT_FOW_STAND_IN_SCORE
     #: The bearing angle is computed along this distance on a given line. Given in meters.
     bear_dist: int = 20
+    #: Input coordinates are provided in an equal-area projection (i.e. NOT WGS84 lat/lon)
+    equal_area: bool = False
+    equal_area_srid: int = 2163
+    #: Timeout in seconds for single segment line decoding
+    timeout: int = 50000
 
 
 DEFAULT_CONFIG = Config()
@@ -101,22 +107,22 @@ def load_config(source: Union[str, TextIOBase, dict]) -> Config:
         raise TypeError("Surprising type")
     return Config._make(
         [
-            opened_source['search_radius'],
-            opened_source['max_dnp_deviation'],
-            opened_source['tolerated_dnp_dev'],
-            opened_source['min_score'],
-            {
-                FRC(int(key)): FRC(value)
-                for (key, value) in opened_source['tolerated_lfrc'].items()
-            },
-            opened_source['candidate_threshold'],
-            opened_source['max_bear_deviation'],
-            opened_source['fow_weight'],
-            opened_source['frc_weight'],
-            opened_source['geo_weight'],
-            opened_source['bear_weight'],
-            opened_source['fow_standin_score'],
-            opened_source['bear_dist']
+            opened_source["search_radius"],
+            opened_source["max_dnp_deviation"],
+            opened_source["tolerated_dnp_dev"],
+            opened_source["min_score"],
+            {FRC(int(key)): FRC(value) for (key, value) in opened_source["tolerated_lfrc"].items()},
+            opened_source["candidate_threshold"],
+            opened_source["rel_candidate_threshold"],
+            opened_source["max_bear_deviation"],
+            opened_source["fow_weight"],
+            opened_source["frc_weight"],
+            opened_source["geo_weight"],
+            opened_source["bear_weight"],
+            opened_source["fow_standin_score"],
+            opened_source["bear_dist"],
+            opened_source["equal_area"],
+            opened_source["timeout"],
         ]
     )
 

--- a/openlr_dereferencer/decoding/configuration.py
+++ b/openlr_dereferencer/decoding/configuration.py
@@ -48,7 +48,7 @@ class Config(NamedTuple):
     min_score: float = 0.3
     #: For every LFRCNP possibly present in an LRP, this defines
     #: what lowest FRC in a considered route is acceptable
-    tolerated_lfrc: Dict[FRC, FRC] = {frc: frc if frc < 4 else 6 for frc in FRC}
+    tolerated_lfrc: Dict[FRC, FRC] = {frc: frc for frc in FRC}
     #: Partial candidate line threshold, measured in meters
     #:
     #: To find candidates, the LRP coordinates are projected against any line in the local area.
@@ -56,7 +56,6 @@ class Config(NamedTuple):
     #: beginning at the projection point is considered to be the candidate. Else, the candidate
     #: snaps onto the starting point (or ending point, when it is the last LRP)
     candidate_threshold: int = 20
-    rel_candidate_threshold: float = 1.0
     #: Defines a threshold for the bearing difference. Candidates differing too much from
     #: the LRP's bearing value are pre-filtered.
     max_bear_deviation: float = 45.0
@@ -113,7 +112,6 @@ def load_config(source: Union[str, TextIOBase, dict]) -> Config:
             opened_source["min_score"],
             {FRC(int(key)): FRC(value) for (key, value) in opened_source["tolerated_lfrc"].items()},
             opened_source["candidate_threshold"],
-            opened_source["rel_candidate_threshold"],
             opened_source["max_bear_deviation"],
             opened_source["fow_weight"],
             opened_source["frc_weight"],

--- a/openlr_dereferencer/decoding/configuration.py
+++ b/openlr_dereferencer/decoding/configuration.py
@@ -76,7 +76,7 @@ class Config(NamedTuple):
     bear_dist: int = 20
     #: Input coordinates are provided in an equal-area projection (i.e. NOT WGS84 lat/lon)
     equal_area: bool = False
-    equal_area_srid: int = 2163
+    equal_area_srid: int = 9311
     #: Timeout in seconds for single segment line decoding
     timeout: int = 50000
 

--- a/openlr_dereferencer/decoding/error.py
+++ b/openlr_dereferencer/decoding/error.py
@@ -1,2 +1,5 @@
 class LRDecodeError(Exception):
     "An error that happens through decoding location references"
+
+class LRTimeoutError(Exception):
+    "A timeout error that happens through decoding location references"

--- a/openlr_dereferencer/decoding/line_decoding.py
+++ b/openlr_dereferencer/decoding/line_decoding.py
@@ -11,23 +11,20 @@ from .configuration import Config
 
 
 def dereference_path(
-        lrps: List[LocationReferencePoint],
-        reader: MapReader,
-        config: Config,
-        observer: Optional[DecoderObserver]
+    lrps: List[LocationReferencePoint], reader: MapReader, config: Config, observer: Optional[DecoderObserver]
 ) -> List[Route]:
     "Decode the location reference path, without considering any offsets"
     first_lrp = lrps[0]
     first_candidates = list(nominate_candidates(first_lrp, reader, config, observer, False))
-
     linelocationpath = match_tail(first_lrp, first_candidates, lrps[1:], reader, config, observer)
     return linelocationpath
 
 
-def decode_line(reference: LineLocationReference, reader: MapReader, config: Config,
-                observer: Optional[DecoderObserver]) -> LineLocation:
+def decode_line(
+    reference: LineLocationReference, reader: MapReader, config: Config, observer: Optional[DecoderObserver]
+) -> LineLocation:
     """Decodes an openLR line location reference
 
     Candidates are searched in a radius of `radius` meters around an LRP."""
     parts = dereference_path(reference.points, reader, config, observer)
-    return build_line_location(parts, reference)
+    return build_line_location(parts, reference, config.equal_area)

--- a/openlr_dereferencer/decoding/line_location.py
+++ b/openlr_dereferencer/decoding/line_location.py
@@ -76,4 +76,4 @@ def build_line_location(path: List[Route], reference: LineLocationReference, equ
     The result will be a trimmed list of Line objects, with minimized offset values"""
     p_off = reference.poffs * path[0].length()
     n_off = reference.noffs * path[-1].length()
-    return LineLocation(remove_offsets(combine_routes(path, equal_area), p_off, n_off))
+    return LineLocation(remove_offsets(combine_routes(path, equal_area), p_off, n_off, equal_area))

--- a/openlr_dereferencer/decoding/line_location.py
+++ b/openlr_dereferencer/decoding/line_location.py
@@ -6,6 +6,7 @@ from ..maps import Line
 from .path_math import remove_offsets
 from .routes import Route, PointOnLine
 
+
 class LineLocation:
     """A dereferenced line location. Create it from a combined Route which represents the
     line location path. The attribute `lines` is the list of involved `Line` elements.
@@ -49,7 +50,7 @@ def get_lines(line_location_path: Iterable[Route]) -> List[Line]:
     return result
 
 
-def combine_routes(line_location_path: Iterable[Route]) -> Route:
+def combine_routes(line_location_path: Iterable[Route], equal_area: bool = False) -> Route:
     """Builds the whole location reference path
 
     Args:
@@ -61,18 +62,18 @@ def combine_routes(line_location_path: Iterable[Route]) -> Route:
         The combined route
     """
     path = get_lines(line_location_path)
-    start = PointOnLine(path.pop(0), line_location_path[0].start.relative_offset)
+    start = PointOnLine(path.pop(0), line_location_path[0].start.relative_offset, equal_area)
     if path:
-        end = PointOnLine(path.pop(), line_location_path[-1].end.relative_offset)
+        end = PointOnLine(path.pop(), line_location_path[-1].end.relative_offset, equal_area)
     else:
-        end = PointOnLine(start.line, line_location_path[-1].end.relative_offset)
+        end = PointOnLine(start.line, line_location_path[-1].end.relative_offset, equal_area)
     return Route(start, path, end)
 
 
-def build_line_location(path: List[Route], reference: LineLocationReference) -> LineLocation:
+def build_line_location(path: List[Route], reference: LineLocationReference, equal_area: bool = False) -> LineLocation:
     """Builds a LineLocation object from all location reference path parts and the offset values.
 
     The result will be a trimmed list of Line objects, with minimized offset values"""
     p_off = reference.poffs * path[0].length()
     n_off = reference.noffs * path[-1].length()
-    return LineLocation(remove_offsets(combine_routes(path), p_off, n_off))
+    return LineLocation(remove_offsets(combine_routes(path, equal_area), p_off, n_off))

--- a/openlr_dereferencer/decoding/path_math.py
+++ b/openlr_dereferencer/decoding/path_math.py
@@ -9,7 +9,8 @@ from openlr import Coordinates, LocationReferencePoint
 from .error import LRDecodeError
 from .routes import Route, PointOnLine
 from ..maps import Line
-from ..maps.wgs84 import interpolate, bearing, line_string_length
+from ..maps import wgs84
+from ..maps import equal_area as ee
 
 
 def remove_offsets(path: Route, p_off: float, n_off: float) -> Route:
@@ -21,16 +22,14 @@ def remove_offsets(path: Route, p_off: float, n_off: float) -> Route:
     debug(f"first line's offset is {path.absolute_start_offset}")
     remaining_poff = p_off + path.absolute_start_offset
     while remaining_poff >= lines[0].length:
-        debug(f"Remaining positive offset {remaining_poff} is greater than "
-              f"the first line. Removing it.")
+        debug(f"Remaining positive offset {remaining_poff} is greater than the first line. Removing it.")
         remaining_poff -= lines.pop(0).length
         if not lines:
             raise LRDecodeError("Offset is bigger than line location path")
     # Remove negative offset
     remaining_noff = n_off + path.absolute_end_offset
     while remaining_noff >= lines[-1].length:
-        debug(f"Remaining negative offset {remaining_noff} is greater than "
-              f"the last line. Removing it.")
+        debug(f"Remaining negative offset {remaining_noff} is greater than the last line. Removing it.")
         remaining_noff -= lines.pop().length
         if not lines:
             raise LRDecodeError("Offset is bigger than line location path")
@@ -42,7 +41,7 @@ def remove_offsets(path: Route, p_off: float, n_off: float) -> Route:
     return Route(
         PointOnLine.from_abs_offset(start_line, remaining_poff),
         lines,
-        PointOnLine.from_abs_offset(end_line, end_line.length - remaining_noff)
+        PointOnLine.from_abs_offset(end_line, end_line.length - remaining_noff),
     )
 
 
@@ -51,7 +50,7 @@ def coords(lrp: LocationReferencePoint) -> Coordinates:
     return Coordinates(lrp.lon, lrp.lat)
 
 
-def project(line: Line, coord: Coordinates) -> PointOnLine:
+def project(line: Line, coord: Coordinates, equal_area: bool = False) -> PointOnLine:
     """Computes the nearest point to `coord` on the line
 
     Returns: The point on `line` where this nearest point resides"""
@@ -59,12 +58,16 @@ def project(line: Line, coord: Coordinates) -> PointOnLine:
 
     to_projection_point = substring(line.geometry, 0.0, fraction, normalized=True)
 
-    meters_to_projection_point = line_string_length(to_projection_point)
-    geometry_length = line_string_length(line.geometry)
+    if not equal_area:
+        meters_to_projection_point = wgs84.line_string_length(to_projection_point)
+        geometry_length = wgs84.line_string_length(line.geometry)
+    else:
+        meters_to_projection_point = ee.line_string_length(to_projection_point)
+        geometry_length = ee.line_string_length(line.geometry)
 
     length_fraction = meters_to_projection_point / geometry_length
 
-    return PointOnLine(line, length_fraction)
+    return PointOnLine(line, length_fraction, equal_area)
 
 
 def linestring_coords(line: LineString) -> List[Coordinates]:
@@ -73,10 +76,7 @@ def linestring_coords(line: LineString) -> List[Coordinates]:
 
 
 def compute_bearing(
-        lrp: LocationReferencePoint,
-        candidate: PointOnLine,
-        is_last_lrp: bool,
-        bear_dist: float
+    lrp: LocationReferencePoint, candidate: PointOnLine, is_last_lrp: bool, bear_dist: float, equal_area: bool = False
 ) -> float:
     "Returns the bearing angle of a partial line in degrees in the range 0.0 .. 360.0"
     line1, line2 = candidate.split()
@@ -89,6 +89,12 @@ def compute_bearing(
         if line2 is None:
             return 0.0
         coordinates = linestring_coords(line2)
-    bearing_point = interpolate(coordinates, bear_dist)
-    bear = bearing(coordinates[0], bearing_point)
-    return degrees(bear) % 360
+    if not equal_area:
+        bearing_point = wgs84.interpolate(coordinates, bear_dist)
+        bear = wgs84.bearing(coordinates[0], bearing_point)
+        result = degrees(bear) % 360
+    else:
+        bearing_point = ee.interpolate(coordinates, bear_dist)
+        bear = ee.bearing(coordinates[0], bearing_point)
+        result = (degrees(bear) + 360) % 360
+    return result

--- a/openlr_dereferencer/decoding/path_math.py
+++ b/openlr_dereferencer/decoding/path_math.py
@@ -13,7 +13,7 @@ from ..maps import wgs84
 from ..maps import equal_area as ee
 
 
-def remove_offsets(path: Route, p_off: float, n_off: float) -> Route:
+def remove_offsets(path: Route, p_off: float, n_off: float, equal_area: bool = False) -> Route:
     """Remove start+end offsets, measured in meters, from a route and return the result"""
     debug(f"Will consider positive offset = {p_off} m and negative offset {n_off} m.")
     lines = path.lines
@@ -39,9 +39,9 @@ def remove_offsets(path: Route, p_off: float, n_off: float) -> Route:
     else:
         end_line = start_line
     return Route(
-        PointOnLine.from_abs_offset(start_line, remaining_poff),
+        PointOnLine.from_abs_offset(start_line, remaining_poff, equal_area),
         lines,
-        PointOnLine.from_abs_offset(end_line, end_line.length - remaining_noff),
+        PointOnLine.from_abs_offset(end_line, end_line.length - remaining_noff, equal_area),
     )
 
 

--- a/openlr_dereferencer/decoding/point_locations.py
+++ b/openlr_dereferencer/decoding/point_locations.py
@@ -11,7 +11,8 @@ from openlr import (
 from ..maps import MapReader, path_length
 from ..maps.abstract import Line
 from ..observer import DecoderObserver
-from ..maps.wgs84 import interpolate
+from ..maps import wgs84
+from ..maps import equal_area as ee
 from .line_decoding import dereference_path
 from .line_location import get_lines, Route, combine_routes
 from .configuration import Config
@@ -27,10 +28,15 @@ class PointAlongLine(NamedTuple):
     positive_offset: float
     side: SideOfRoad
     orientation: Orientation
+    config: Config
 
     def coordinates(self) -> Coordinates:
         "Returns the geo coordinates of the point"
-        return interpolate(list(self.line.coordinates()), self.positive_offset)
+        if not self.config.equal_area:
+            coords = wgs84.interpolate(list(self.line.coordinates()), self.positive_offset)
+        else:
+            coords = ee.interpolate_ee(list(self.line.coordinates()), self.positive_offset)
+        return coords
 
 
 def point_along_linelocation(route: Route, length: float) -> Tuple[Line, float]:
@@ -54,16 +60,13 @@ def point_along_linelocation(route: Route, length: float) -> Tuple[Line, float]:
 
 
 def decode_pointalongline(
-        reference: PointAlongLineLocationReference,
-        reader: MapReader,
-        config: Config,
-        observer: Optional[DecoderObserver]
+    reference: PointAlongLineLocationReference, reader: MapReader, config: Config, observer: Optional[DecoderObserver]
 ) -> PointAlongLine:
     "Decodes a point along line location reference into a PointAlongLine object"
-    path = combine_routes(dereference_path(reference.points, reader, config, observer))
+    path = combine_routes(dereference_path(reference.points, reader, config, observer), config.equal_area)
     absolute_offset = path.length() * reference.poffs
     line_object, line_offset = point_along_linelocation(path, absolute_offset)
-    return PointAlongLine(line_object, line_offset, reference.sideOfRoad, reference.orientation)
+    return PointAlongLine(line_object, line_offset, reference.sideOfRoad, reference.orientation, config)
 
 
 class PoiWithAccessPoint(NamedTuple):
@@ -73,20 +76,25 @@ class PoiWithAccessPoint(NamedTuple):
     side: SideOfRoad
     orientation: Orientation
     poi: Coordinates
+    config: Config
 
     def access_point_coordinates(self) -> Coordinates:
         "Returns the geo coordinates of the access point"
-        return interpolate(list(self.line.coordinates()), self.positive_offset)
+        if not self.config.equal_area:
+            result = wgs84.interpolate(list(self.line.coordinates()), self.positive_offset)
+        else:
+            result = ee.interpolate(list(self.line.coordinates()), self.positive_offset)
+        return result
 
 
 def decode_poi_with_accesspoint(
-        reference: PoiWithAccessPointLocationReference,
-        reader: MapReader,
-        config: Config,
-        observer: Optional[DecoderObserver]
+    reference: PoiWithAccessPointLocationReference,
+    reader: MapReader,
+    config: Config,
+    observer: Optional[DecoderObserver],
 ) -> PoiWithAccessPoint:
     "Decodes a poi with access point location reference into a PoiWithAccessPoint"
-    path = combine_routes(dereference_path(reference.points, reader, config, observer))
+    path = combine_routes(dereference_path(reference.points, reader, config, observer), config.equal_area)
     absolute_offset = path_length(get_lines([path])) * reference.poffs
     line, line_offset = point_along_linelocation(path, absolute_offset)
     return PoiWithAccessPoint(
@@ -95,4 +103,5 @@ def decode_poi_with_accesspoint(
         reference.sideOfRoad,
         reference.orientation,
         Coordinates(reference.lon, reference.lat),
+        config,
     )

--- a/openlr_dereferencer/decoding/routes.py
+++ b/openlr_dereferencer/decoding/routes.py
@@ -5,7 +5,7 @@ from shapely.geometry import LineString
 from shapely.ops import substring
 from openlr import Coordinates
 from ..maps.abstract import Line, path_length
-from ..maps.wgs84 import interpolate, split_line, join_lines, line_string_length
+from ..maps import wgs84, equal_area as ee
 
 
 class PointOnLine(NamedTuple):
@@ -16,14 +16,22 @@ class PointOnLine(NamedTuple):
     #: Its value is member of the interval [0.0, 1.0].
     #: A value of 0 references the starting point of the line.
     relative_offset: float
+    equal_area: bool = False
 
     def _geometry_length_from_start(self):
-        geometry_length = line_string_length(self.line.geometry)
+        if not self.equal_area:
+            geometry_length = wgs84.line_string_length(self.line.geometry)
+        else:
+            geometry_length = ee.line_string_length(self.line.geometry)
         return geometry_length * self.relative_offset
 
     def position(self) -> Coordinates:
         "Returns the actual geo position"
-        return interpolate(self.line.coordinates(), self._geometry_length_from_start())
+        if not self.equal_area:
+            pos = wgs84.interpolate(self.line.coordinates(), self._geometry_length_from_start())
+        else:
+            pos = ee.interpolate(self.line.coordinates(), self._geometry_length_from_start())
+        return pos
 
     def distance_from_start(self) -> float:
         "Returns the distance in meters from the start of the line to the point"
@@ -35,18 +43,22 @@ class PointOnLine(NamedTuple):
 
     def split(self) -> Tuple[Optional[LineString], Optional[LineString]]:
         "Splits the Line element that this point is along and returns the parts"
-        return split_line(self.line.geometry, self._geometry_length_from_start())
+        if not self.equal_area:
+            result = wgs84.split_line(self.line.geometry, self._geometry_length_from_start())
+        else:
+            result = ee.split_line(self.line.geometry, self._geometry_length_from_start())
+        return result
 
     @classmethod
-    def from_abs_offset(cls, line: Line, meters_into: float):
+    def from_abs_offset(cls, line: Line, meters_into: float, equal_area: bool = False):
         """Build a PointOnLine from an absolute offset value.
 
         Negative offsets are recognized and subtracted."""
         if meters_into >= 0.0:
-            return cls(line, meters_into / line.length)
+            return cls(line, meters_into / line.length, equal_area)
         else:
             negative_meters_into = line.length + meters_into
-            return cls(line, negative_meters_into / line.length)
+            return cls(line, negative_meters_into / line.length, equal_area)
 
 
 class Route(NamedTuple):
@@ -95,10 +107,7 @@ class Route(NamedTuple):
         "Returns the shape of the route. The route is has to be continuous."
         if self.start.line.line_id == self.end.line.line_id:
             return substring(
-                self.start.line.geometry,
-                self.start.relative_offset,
-                self.end.relative_offset,
-                normalized=True
+                self.start.line.geometry, self.start.relative_offset, self.end.relative_offset, normalized=True
             )
 
         result = []
@@ -109,8 +118,7 @@ class Route(NamedTuple):
         result += [line.geometry for line in self.path_inbetween]
         if last is not None:
             result.append(last)
-
-        return join_lines(result)
+        return wgs84.join_lines(result)
 
     def coordinates(self) -> List[Coordinates]:
         "Returns all Coordinates of this line location"

--- a/openlr_dereferencer/decoding/scoring.py
+++ b/openlr_dereferencer/decoding/scoring.py
@@ -7,7 +7,7 @@ with `1.0` being an exact match and 0.0 being a non-match."""
 
 from logging import debug
 from openlr import FRC, FOW, LocationReferencePoint
-from ..maps.wgs84 import distance
+from ..maps import wgs84, equal_area as ee
 from .path_math import coords, PointOnLine, compute_bearing
 from .configuration import Config
 
@@ -17,12 +17,15 @@ def score_frc(wanted: FRC, actual: FRC) -> float:
     return 1.0 - abs(actual - wanted) / 7
 
 
-def score_geolocation(wanted: LocationReferencePoint, actual: PointOnLine, radius: float) -> float:
+def score_geolocation(wanted: LocationReferencePoint, actual: PointOnLine, radius: float, equal_area: bool) -> float:
     """Scores the geolocation of a candidate.
 
     A distance of `radius` or more will result in a 0.0 score."""
     debug(f"Candidate coords are {actual.position()}")
-    dist = distance(coords(wanted), actual.position())
+    if not equal_area:
+        dist = wgs84.distance(coords(wanted), actual.position())
+    else:
+        dist = ee.distance(coords(wanted), actual.position())
     if dist < radius:
         return 1.0 - dist / radius
     return 0.0
@@ -45,13 +48,13 @@ def angle_sector(angle: float) -> int:
 
 
 def angle_sector_difference(angle1: float, angle2: float) -> int:
-    """"The distance of the two sectors containing the angles values, respectively
+    """The distance of the two sectors containing the angles values, respectively
     Args:
         angle1, angle2:
             the values are expected in degrees
     Returns:
         Value in the range [0,16]
-        """
+    """
 
     sector_diff = abs(angle_sector(angle1) - angle_sector(angle2))
     "Differences should be between 0 and 16. Direction (clockwise or counter clockwise) between the two sectors should "
@@ -99,32 +102,27 @@ def score_angle_difference(angle1: float, angle2: float) -> float:
 
 
 def score_bearing(
-        wanted: LocationReferencePoint,
-        actual: PointOnLine,
-        is_last_lrp: bool,
-        bear_dist: float
+    wanted: LocationReferencePoint, actual: PointOnLine, is_last_lrp: bool, bear_dist: float, equal_area: bool
 ) -> float:
     """Scores the difference between expected and actual bearing angle.
 
     A difference of 0° will result in a 1.0 score, while 180° will cause a score of 0.0."""
-    bear = compute_bearing(wanted, actual, is_last_lrp, bear_dist)
+    bear = compute_bearing(wanted, actual, is_last_lrp, bear_dist, equal_area)
     return score_angle_sector_differences(wanted.bear, bear)
 
 
 def score_lrp_candidate(
-        wanted: LocationReferencePoint,
-        candidate: PointOnLine, config: Config, is_last_lrp: bool
+    wanted: LocationReferencePoint, candidate: PointOnLine, config: Config, is_last_lrp: bool
 ) -> float:
     """Scores the candidate (line) for the LRP.
 
     This is the average of fow, frc, geo and bearing score."""
     debug(f"scoring {candidate} with config {config}")
-    geo_score = config.geo_weight * score_geolocation(wanted, candidate, config.search_radius)
+    geo_score = config.geo_weight * score_geolocation(wanted, candidate, config.search_radius, config.equal_area)
     fow_score = config.fow_weight * config.fow_standin_score[wanted.fow][candidate.line.fow]
     frc_score = config.frc_weight * score_frc(wanted.frc, candidate.line.frc)
-    bear_score = score_bearing(wanted, candidate, is_last_lrp, config.bear_dist)
+    bear_score = score_bearing(wanted, candidate, is_last_lrp, config.bear_dist, config.equal_area)
     bear_score *= config.bear_weight
     score = fow_score + frc_score + geo_score + bear_score
-    debug(f"Score: geo {geo_score} + fow {fow_score} + frc {frc_score} "
-          f"+ bear {bear_score} = {score}")
+    debug(f"Score: geo {geo_score} + fow {fow_score} + frc {frc_score} bear {bear_score} = {score}")
     return score

--- a/openlr_dereferencer/example_postgres_map/__init__.py
+++ b/openlr_dereferencer/example_postgres_map/__init__.py
@@ -1,0 +1,112 @@
+"""The example map format described in `map_format.md`, conforming to
+the interface in openlr_dereferencer.maps"""
+
+from typing import Iterable
+from openlr import Coordinates
+from .primitives import Line, Node, ExampleMapError
+from openlr_dereferencer.maps import MapReader
+from stl_general import database as db
+
+
+class PostgresMapReader(MapReader):
+    """
+    This is a reader for the example map format described in `map_format.md`.
+
+    Create an instance with: `ExampleMapReader('example.sqlite')`.
+    """
+
+    def __init__(self, db_nickname, db_schema, lines_tbl_name, nodes_tbl_name, srid=4326):
+        self.db_nickname = db_nickname
+        self.db_schema = db_schema
+        self.lines_tbl_name = lines_tbl_name
+        self.nodes_tbl_name = nodes_tbl_name
+        self.connection = None
+        self.srid = srid
+
+    def __enter__(self):
+        assert self.db_nickname is not None
+        self.connection = db.connect_db(nickname=self.db_nickname, driver="psycopg2")
+        self.cursor = self.connection.cursor()
+        return self
+
+    def __exit__(self, *exc_info):
+        # make sure the dbconnection gets closed
+        try:
+            close_it = self.connection.close
+        except AttributeError:
+            pass
+        else:
+            close_it()
+
+    def get_line(self, line_id: int) -> Line:
+        # Just verify that this line ID exists.
+        self.cursor.execute(
+            f"SELECT line_id FROM {self.db_schema}.{self.lines_tbl_name} WHERE line_id=%s",
+            (line_id,),
+        )
+        if self.cursor.fetchone() is None:
+            raise ExampleMapError(f"The line {line_id} does not exist")
+        return Line(self, line_id)
+
+    def get_lines(self) -> Iterable[Line]:
+        self.cursor.execute(f"SELECT line_id FROM {self.db_schema}.{self.lines_tbl_name}")
+        for (line_id,) in self.cursor.fetchall():
+            yield Line(self, line_id)
+
+    def get_linecount(self) -> int:
+        self.cursor.execute(f"SELECT COUNT(*) FROM {self.db_schema}.{self.lines_tbl_name}")
+        (count,) = self.cursor.fetchone()
+        return count
+
+    def get_node(self, node_id: int) -> Node:
+        self.cursor.execute(
+            f"SELECT node_id FROM {self.db_schema}.{self.nodes_tbl_name} WHERE node_id=%s",
+            (node_id,),
+        )
+        (node_id,) = self.cursor.fetchone()
+        return Node(self, node_id)
+
+    def get_nodes(self) -> Iterable[Node]:
+        self.cursor.execute(f"SELECT node_id FROM {self.db_schema}.{self.nodes_tbl_name}")
+        for (node_id,) in self.cursor.fetchall():
+            yield Node(self, node_id)
+
+    def get_nodecount(self) -> int:
+        self.cursor.execute(f"SELECT COUNT(*) FROM {self.db_schema}.{self.nodes_tbl_name}")
+        (count,) = self.cursor.fetchone()
+        return count
+
+    def find_nodes_close_to(self, coord: Coordinates, dist: float) -> Iterable[Node]:
+        """Finds all nodes in a given radius, given in meters
+        Yields every node within this distance to `coord`."""
+        lon, lat = coord.lon, coord.lat
+        stmt = f"""
+            SELECT
+                node_id
+            FROM {self.db_schema}.{self.nodes_tbl_name}
+            WHERE ST_DWithin(
+                ST_SetSRID(ST_MakePoint(%s,%s), {self.srid}),
+                geometry,
+                %s
+            );
+        """
+        self.cursor.execute(stmt, (lon, lat, dist))
+        for (node_id,) in self.cursor.fetchall():
+            yield Node(self, node_id)
+
+    def find_lines_close_to(self, coord: Coordinates, dist: float) -> Iterable[Line]:
+        "Yields all lines within `dist` meters around `coord`"
+        lon, lat = coord.lon, coord.lat
+        stmt = f"""
+            SELECT
+                line_id
+            FROM {self.db_schema}.{self.lines_tbl_name} 
+            WHERE ST_DWithin(
+                ST_SetSRID(ST_MakePoint(%s,%s), {self.srid}),
+                geometry,
+                %s
+            );
+        """
+        self.cursor.execute(stmt, (lon, lat, dist))
+        for (line_id,) in self.cursor.fetchall():
+            yield Line(self, line_id)

--- a/openlr_dereferencer/example_postgres_map/init.sql
+++ b/openlr_dereferencer/example_postgres_map/init.sql
@@ -1,0 +1,20 @@
+CREATE TABLE openlr_nodes (
+    node_id BIGINT PRIMARY KEY,
+    geometry geometry(Point, 4326) DEFAULT NULL::geometry
+);
+
+CREATE TABLE openlr_lines (
+    line_id BIGINT PRIMARY KEY,
+    way_id BIGINT,
+    startnode BIGINT NOT NULL,
+    endnode BIGINT NOT NULL,
+    frc integer NOT NULL,
+    fow integer NOT NULL,
+    geometry geometry(LineString, 4326) DEFAULT NULL::geometry,
+    bearing float8
+);
+
+CREATE INDEX idx_openlr_nodes_geometry ON openlr_nodes USING GIST (geometry gist_geometry_ops_2d);
+CREATE INDEX idx_openlr_lines_geometry ON openlr_lines USING GIST (geometry gist_geometry_ops_2d);
+CREATE INDEX idx_openlr_lines_startnode ON openlr_lines(startnode int8_ops);
+CREATE INDEX idx_openlr_lines_endnode ON openlr_lines(endnode int8_ops);

--- a/openlr_dereferencer/example_postgres_map/primitives.py
+++ b/openlr_dereferencer/example_postgres_map/primitives.py
@@ -1,0 +1,228 @@
+"Contains the Node and the Line class of the example format"
+from collections import namedtuple
+from itertools import chain
+import functools
+from typing import Iterable
+from openlr import Coordinates, FRC, FOW
+from shapely.geometry import LineString
+from shapely import wkt
+from openlr_dereferencer.maps import Line as AbstractLine, Node as AbstractNode
+
+LineNode = namedtuple("LineNode", ["start_node", "end_node"])
+
+
+class Line(AbstractLine):
+    "Line object implementation for the example format"
+
+    def __init__(self, map_reader, line_id: int):
+        if not isinstance(line_id, int):
+            raise ExampleMapError(f"Line id '{line_id}' has confusing type {type(line_id)}")
+        self.map_reader = map_reader
+        self.db_schema = map_reader.db_schema
+        self.lines_tbl_name = map_reader.lines_tbl_name
+        self.nodes_tbl_name = map_reader.nodes_tbl_name
+        self.line_id_internal = line_id
+        self.srid = map_reader.srid
+        self._start_node = None
+        self._end_node = None
+        self._fow = None
+        self._frc = None
+        self._geometry = None
+        self._numpoints = None
+        self._length = None
+
+    def __repr__(self):
+        return f"Line with id={self.line_id} of length {self.length}"
+
+    @property
+    def line_id(self) -> int:
+        "Returns the line id"
+        return self.line_id_internal
+
+    def get_and_store_database_info(self):
+        stmt = f"""
+            SELECT 
+                startnode,
+                endnode,
+                fow,
+                frc,
+                ST_astext(geometry),
+                ST_NumPoints(geometry),
+                st_length(geometry)
+            FROM {self.db_schema}.{self.lines_tbl_name}
+            WHERE line_id = %s
+        """
+        self.map_reader.cursor.execute(stmt, (self.line_id,))
+        (startnode, endnode, fow, frc, geometry, num_points, length) = self.map_reader.cursor.fetchone()
+        self._start_node = Node(self.map_reader, startnode)
+        self._end_node = Node(self.map_reader, endnode)
+        self._fow = FOW(fow)
+        self._frc = FRC(frc)
+        self._geometry = wkt.loads(geometry)
+        self._numpoints = num_points
+        self._length = length
+
+    @property
+    def start_node(self) -> "Node":
+        "Returns the node from which this line comes from"
+        if not self._start_node:
+            self.get_and_store_database_info()
+        return self._start_node
+
+    @property
+    def end_node(self) -> "Node":
+        "Returns the node to which this line goes"
+        if not self._end_node:
+            self.get_and_store_database_info()
+        return self._end_node
+
+    @property
+    def fow(self) -> FOW:
+        "Returns the form of way for this line"
+        if not self._fow:
+            self.get_and_store_database_info()
+        return self._fow
+
+    @property
+    def frc(self) -> FRC:
+        "Returns the functional road class for this line"
+        if not self._frc:
+            self.get_and_store_database_info()
+        return self._frc
+
+    @property
+    def length(self) -> float:
+        "Length of line in meters"
+        if not self._length:
+            self.get_and_store_database_info()
+        return self._length
+
+    @property
+    def way_ids(self) -> int:
+        stmt = f"SELECT distinct(way_ids) FROM {self.db_schema}.{self.lines_tbl_name} WHERE line_id = %s"
+        self.map_reader.cursor.execute(stmt, (self.line_id,))
+        (result,) = self.map_reader.cursor.fetchone()
+        return result
+
+    @property
+    def geometry(self) -> LineString:
+        "Returns the line geometry"
+        # chg list comp to single call
+        if not self._geometry:
+            self.get_and_store_database_info()
+        return self._geometry
+
+    def num_points(self) -> int:
+        "Returns how many points the path geometry contains"
+        if not self._numpoints:
+            self.get_and_store_database_info()
+        return self._numpoints
+
+    def distance_to(self, coord) -> float:
+        "Returns the distance of this line to `coord` in meters"
+        stmt = f"""
+            SELECT
+                ST_Distance(
+                    ST_SetSRID(ST_MakePoint(%s,%s), {self.srid}),
+                    geometry
+                )
+            FROM {self.db_schema}.{self.lines_tbl_name} 
+            WHERE
+                line_id = %s;
+        """
+        cur = self.map_reader.cursor
+        cur.execute(stmt, (coord.lon, coord.lat, self.line_id))
+        (dist,) = cur.fetchone()
+        if dist is None:
+            return 0.0
+        return dist
+
+    def point_n(self, index) -> Coordinates:
+        "Returns the `n` th point in the path geometry, starting at 0"
+        stmt = f"""
+        SELECT ST_X(ST_PointN(geometry, %s)), ST_Y(ST_PointN(geometry, %s))
+        FROM {self.db_schema}.{self.lines_tbl_name}
+        WHERE line_id = %s
+        """
+        self.map_reader.cursor.execute(stmt, (index, index, self.line_id))
+        (lon, lat) = self.map_reader.cursor.fetchone()
+        if lon is None or lat is None:
+            raise Exception(f"line {self.line_id} has no point {index}!")
+        return Coordinates(lon, lat)
+
+    def near_nodes(self, distance):
+        "Yields every point within a certain distance, in meters."
+        stmt = f"""
+            SELECT
+                nodes.node_id
+            FROM {self.db_schema}.{self.nodes_tbl_name} nodes, {self.db_schema}.{self.lines_tbl_name} lines
+            WHERE
+                lines.line_id = %s AND 
+                ST_DWithin(
+                    nodes.geometry,
+                    lines.geometry,
+                    %s
+                )
+        """
+        self.map_reader.cursor.execute(stmt, (self.line_id, distance))
+        for (point_id,) in self.map_reader.cursor.fetchall():
+            yield self.map_reader.get_node(point_id)
+
+
+class Node(AbstractNode):
+    "Node class implementation for example_sqlite_map"
+
+    def __init__(self, map_reader, node_id: int):
+        if not isinstance(node_id, int):
+            raise ExampleMapError(f"Node id '{id}' has confusing type {type(node_id)}")
+        self.map_reader = map_reader
+        self.db_schema = map_reader.db_schema
+        self.lines_tbl_name = map_reader.lines_tbl_name
+        self.nodes_tbl_name = map_reader.nodes_tbl_name
+        self.node_id_internal = node_id
+
+    @property
+    def node_id(self):
+        return self.node_id_internal
+
+    @property
+    def coordinates(self) -> Coordinates:
+        stmt = f"SELECT ST_X(geometry), ST_Y(geometry) FROM {self.db_schema}.{self.nodes_tbl_name} WHERE node_id = %s"
+        self.map_reader.cursor.execute(stmt, (self.node_id,))
+        geo = self.map_reader.cursor.fetchone()
+        return Coordinates(lon=geo[0], lat=geo[1])
+
+    @functools.cache
+    def outgoing_lines(self) -> Iterable[Line]:
+        stmt = f"SELECT line_id FROM {self.db_schema}.{self.lines_tbl_name} WHERE startnode = %s"
+        self.map_reader.cursor.execute(stmt, (self.node_id,))
+        for (line_id,) in self.map_reader.cursor.fetchall():
+            yield Line(self.map_reader, line_id)
+
+    @functools.cache
+    def incoming_lines(self) -> Iterable[Line]:
+        stmt = f"SELECT line_id FROM {self.db_schema}.{self.lines_tbl_name} WHERE endnode = %s"
+        self.map_reader.cursor.execute(stmt, [self.node_id])
+        for (line_id,) in self.map_reader.cursor.fetchall():
+            yield Line(self.map_reader, line_id)
+
+    @functools.cache
+    def incoming_line_nodes(self) -> Iterable[LineNode]:
+        stmt = f"SELECT startnode, endnode FROM {self.db_schema}.{self.lines_tbl_name} WHERE startnode = %s"
+        self.map_reader.cursor.execute(stmt, (self.node_id,))
+        for (startnode, endnode) in self.map_reader.cursor.fetchall():
+            yield LineNode(Node(self.map_reader, startnode), Node(self.map_reader, endnode))
+
+    @functools.cache
+    def outgoing_line_nodes(self) -> Iterable[LineNode]:
+        stmt = f"SELECT startnode, endnode FROM {self.db_schema}.{self.lines_tbl_name} WHERE endnode = %s"
+        self.map_reader.cursor.execute(stmt, (self.node_id,))
+        for (startnode, endnode) in self.map_reader.cursor.fetchall():
+            yield LineNode(Node(self.map_reader, startnode), Node(self.map_reader, endnode))
+
+    def connected_lines(self) -> Iterable[Line]:
+        return chain(self.incoming_lines(), self.outgoing_lines())
+
+
+class ExampleMapError(Exception):
+    "Some error reading the DB"

--- a/openlr_dereferencer/example_postgres_map/primitives.py
+++ b/openlr_dereferencer/example_postgres_map/primitives.py
@@ -98,13 +98,6 @@ class Line(AbstractLine):
         return self._length
 
     @property
-    def way_ids(self) -> int:
-        stmt = f"SELECT distinct(way_ids) FROM {self.db_schema}.{self.lines_tbl_name} WHERE line_id = %s"
-        self.map_reader.cursor.execute(stmt, (self.line_id,))
-        (result,) = self.map_reader.cursor.fetchone()
-        return result
-
-    @property
     def geometry(self) -> LineString:
         "Returns the line geometry"
         # chg list comp to single call
@@ -170,7 +163,7 @@ class Line(AbstractLine):
 
 
 class Node(AbstractNode):
-    "Node class implementation for example_sqlite_map"
+    "Node class implementation for example_postgres_map"
 
     def __init__(self, map_reader, node_id: int):
         if not isinstance(node_id, int):
@@ -210,14 +203,14 @@ class Node(AbstractNode):
     def incoming_line_nodes(self) -> Iterable[LineNode]:
         stmt = f"SELECT startnode, endnode FROM {self.db_schema}.{self.lines_tbl_name} WHERE startnode = %s"
         self.map_reader.cursor.execute(stmt, (self.node_id,))
-        for (startnode, endnode) in self.map_reader.cursor.fetchall():
+        for startnode, endnode in self.map_reader.cursor.fetchall():
             yield LineNode(Node(self.map_reader, startnode), Node(self.map_reader, endnode))
 
     @functools.cache
     def outgoing_line_nodes(self) -> Iterable[LineNode]:
         stmt = f"SELECT startnode, endnode FROM {self.db_schema}.{self.lines_tbl_name} WHERE endnode = %s"
         self.map_reader.cursor.execute(stmt, (self.node_id,))
-        for (startnode, endnode) in self.map_reader.cursor.fetchall():
+        for startnode, endnode in self.map_reader.cursor.fetchall():
             yield LineNode(Node(self.map_reader, startnode), Node(self.map_reader, endnode))
 
     def connected_lines(self) -> Iterable[Line]:

--- a/openlr_dereferencer/example_postgres_map/primitives.py
+++ b/openlr_dereferencer/example_postgres_map/primitives.py
@@ -189,29 +189,31 @@ class Node(AbstractNode):
     def outgoing_lines(self) -> Iterable[Line]:
         stmt = f"SELECT line_id FROM {self.db_schema}.{self.lines_tbl_name} WHERE startnode = %s"
         self.map_reader.cursor.execute(stmt, (self.node_id,))
-        for (line_id,) in self.map_reader.cursor.fetchall():
-            yield Line(self.map_reader, line_id)
+        return [Line(self.map_reader, line_id[0]) for line_id in self.map_reader.cursor.fetchall()]
 
     @functools.cache
     def incoming_lines(self) -> Iterable[Line]:
         stmt = f"SELECT line_id FROM {self.db_schema}.{self.lines_tbl_name} WHERE endnode = %s"
         self.map_reader.cursor.execute(stmt, [self.node_id])
-        for (line_id,) in self.map_reader.cursor.fetchall():
-            yield Line(self.map_reader, line_id)
+        return [Line(self.map_reader, line_id[0]) for line_id in self.map_reader.cursor.fetchall()]
 
     @functools.cache
     def incoming_line_nodes(self) -> Iterable[LineNode]:
         stmt = f"SELECT startnode, endnode FROM {self.db_schema}.{self.lines_tbl_name} WHERE startnode = %s"
         self.map_reader.cursor.execute(stmt, (self.node_id,))
-        for startnode, endnode in self.map_reader.cursor.fetchall():
-            yield LineNode(Node(self.map_reader, startnode), Node(self.map_reader, endnode))
+        return [
+            LineNode(Node(self.map_reader, startnode), Node(self.map_reader, endnode))
+            for startnode, endnode in self.map_reader.cursor.fetchall()
+        ]
 
     @functools.cache
     def outgoing_line_nodes(self) -> Iterable[LineNode]:
         stmt = f"SELECT startnode, endnode FROM {self.db_schema}.{self.lines_tbl_name} WHERE endnode = %s"
         self.map_reader.cursor.execute(stmt, (self.node_id,))
-        for startnode, endnode in self.map_reader.cursor.fetchall():
-            yield LineNode(Node(self.map_reader, startnode), Node(self.map_reader, endnode))
+        return [
+            LineNode(Node(self.map_reader, startnode), Node(self.map_reader, endnode))
+            for startnode, endnode in self.map_reader.cursor.fetchall()
+        ]
 
     def connected_lines(self) -> Iterable[Line]:
         return chain(self.incoming_lines(), self.outgoing_lines())

--- a/openlr_dereferencer/maps/a_star/__init__.py
+++ b/openlr_dereferencer/maps/a_star/__init__.py
@@ -11,12 +11,15 @@ from .tools import heuristic, LRPathNotFoundError, tautology
 
 class Score(NamedTuple):
     """The score of a single item in the search priority queue"""
+
     f: float
     g: float
+
 
 @total_ordering
 class PQItem(NamedTuple):
     """A single item in the search priority queue"""
+
     score: Score
     node: Node
     line: Line
@@ -27,10 +30,11 @@ class PQItem(NamedTuple):
 
 
 def shortest_path(
-        start: Node,
-        end: Node,
-        linefilter: Callable[[Line], bool] = tautology,
-        maxlen: float = float("inf"),
+    start: Node,
+    end: Node,
+    linefilter: Callable[[Line], bool] = tautology,
+    maxlen: float = float("inf"),
+    equal_area: bool = False,
 ) -> List[Line]:
     """
     Returns a shortest path on the map between two nodes, as list of lines.
@@ -70,7 +74,7 @@ def shortest_path(
     """
 
     # The initial queue item
-    initial = PQItem(Score(heuristic(start, end), 0), start, None, None)
+    initial = PQItem(Score(heuristic(start, end, equal_area), 0), start, None, None)
 
     # The queue
     open_set = [initial]
@@ -112,17 +116,12 @@ def shortest_path(
                 continue
 
             neighbor_g_score = current.score.g + line.length
-            neighbor_f_score = neighbor_g_score + heuristic(neighbor_node, end)
+            neighbor_f_score = neighbor_g_score + heuristic(neighbor_node, end, equal_area)
 
             if neighbor_f_score > maxlen:
                 continue
 
-            neighbor = PQItem(
-                Score(neighbor_f_score, neighbor_g_score),
-                neighbor_node,
-                line,
-                current
-            )
+            neighbor = PQItem(Score(neighbor_f_score, neighbor_g_score), neighbor_node, line, current)
 
             heappush(open_set, neighbor)
 

--- a/openlr_dereferencer/maps/a_star/tools.py
+++ b/openlr_dereferencer/maps/a_star/tools.py
@@ -2,7 +2,8 @@
 
 from functools import lru_cache
 from ..abstract import Node
-from ..wgs84 import distance
+from .. import wgs84
+from .. import equal_area as ee
 
 
 class LRPathNotFoundError(Exception):
@@ -10,11 +11,15 @@ class LRPathNotFoundError(Exception):
 
 
 @lru_cache(maxsize=2)
-def heuristic(current: Node, target: Node) -> float:
+def heuristic(current: Node, target: Node, equal_area: bool = False) -> float:
     """Estimated cost from current to target.
 
     We use geographical distance here as heuristic here."""
-    return distance(current.coordinates, target.coordinates)
+    if not equal_area:
+        dist = wgs84.distance(current.coordinates, target.coordinates)
+    else:
+        dist = ee.distance(current.coordinates, target.coordinates)
+    return dist
 
 
 def tautology(_) -> bool:

--- a/openlr_dereferencer/maps/abstract.py
+++ b/openlr_dereferencer/maps/abstract.py
@@ -45,6 +45,7 @@ they can be used to implement line IDs.
 
 
 from abc import ABC, abstractmethod
+from collections import namedtuple
 from typing import Iterable, Hashable, Sequence
 from openlr import Coordinates, FOW, FRC
 from shapely.geometry import LineString, Point
@@ -57,6 +58,7 @@ class GeometricObject(ABC):
     def geometry(self) -> BaseGeometry:
         "Returns the geometry of this object"
 
+
 class Line(GeometricObject):
     "Abstract Line class, modelling a line coming from a map reader"
 
@@ -64,8 +66,12 @@ class Line(GeometricObject):
     @abstractmethod
     def line_id(self) -> Hashable:
         """Returns the id of the line.
-        
+
         A type is not specified here, but the ID has to be usable as key of a dictionary."""
+
+    @abstractmethod
+    def get_and_store_database_info(self):
+        """Single call to db to fetch all attributes of line and store as class attributes"""
 
     @property
     @abstractmethod
@@ -125,6 +131,14 @@ class Node(GeometricObject):
     @abstractmethod
     def incoming_lines(self) -> Iterable[Line]:
         "Yields all lines coming directly to this node."
+
+    @abstractmethod
+    def outgoing_line_nodes(self) -> Iterable[namedtuple]:
+        """Yields all tuples of start and end nodes for lines where end node is this node"""
+
+    @abstractmethod
+    def incoming_line_nodes(self) -> Iterable[namedtuple]:
+        """Yields all tuples of start and end nodes for lines where start node is this node"""
 
     @abstractmethod
     def connected_lines(self) -> Iterable[Line]:

--- a/openlr_dereferencer/maps/equal_area.py
+++ b/openlr_dereferencer/maps/equal_area.py
@@ -1,0 +1,114 @@
+"Some geo coordinates related tools"
+from math import radians, degrees, sin, cos, pi
+from typing import Sequence, Tuple, Optional
+from geographiclib.geodesic import Geodesic
+from openlr import Coordinates
+from shapely.geometry import LineString
+from itertools import tee
+import numpy as np
+
+
+def distance(point_a: Coordinates, point_b: Coordinates) -> float:
+    "Returns the distance of two coordinates from an equal area projection, assuming units are in meters"
+    dist = np.sqrt((point_b.lat - point_a.lat) ** 2 + (point_b.lon - point_a.lon) ** 2)
+    return dist
+
+
+def pairwise(iterable):
+    "s -> (s0,s1), (s1,s2), (s2, s3), ..."
+    first, second = tee(iterable)
+    next(second, None)
+    return zip(first, second)
+
+
+def line_string_length(line_string: LineString) -> float:
+    """Returns the length of a line string in meters"""
+
+    length = 0
+
+    for coord_a, coord_b in pairwise(line_string.coords):
+        l = np.sqrt((coord_b[0] - coord_a[0]) ** 2 + (coord_b[1] - coord_a[1]) ** 2)
+        length += l
+
+    return length
+
+
+def bearing(point_a: Coordinates, point_b: Coordinates) -> float:
+    """Returns the angle between self and other relative to true north
+    The result of this function is between -pi, pi, including them"""
+
+    bear = np.arctan2(point_b.lon - point_a.lon, point_b.lat - point_a.lat)
+    return bear
+
+
+def extrapolate(point: Coordinates, dist: float, angle: float) -> Coordinates:
+    """Creates a new point that is `dist` meters away in direction `angle`
+    NOTE: angle must be in radians bc it should be the output of bearing()
+    """
+    x0, y0 = point.lon, point.lat
+    theta_rad = pi / 2 - angle
+    x1 = x0 + dist * cos(theta_rad)
+    y1 = y0 + dist * sin(theta_rad)
+    return Coordinates(x1, y1)
+
+
+def interpolate(path: Sequence[Coordinates], distance_meters: float) -> Coordinates:
+    """Go `distance` meters along the `path` and return the resulting point
+    When the length of the path is too short, returns its last coordinate"""
+    remaining_distance = distance_meters
+    segments = [(path[i], path[i + 1]) for i in range(len(path) - 1)]
+    for point1, point2 in segments:
+        segment_length = distance(point1, point2)
+        if remaining_distance == 0.0:
+            return point1
+        if remaining_distance < segment_length:
+            angle = bearing(point1, point2)
+            return extrapolate(point1, remaining_distance, angle)
+        remaining_distance -= segment_length
+    return segments[-1][1]
+
+
+def split_line(line: LineString, meters_into: float) -> Tuple[Optional[LineString], Optional[LineString]]:
+    "Splits a line at `meters_into` meters and returns the two parts. A part is None if it would be a Point"
+    first_part = []
+    second_part = []
+    remaining_offset = meters_into
+    splitpoint = None
+    for point_from, point_to in pairwise(line.coords):
+        if splitpoint is None:
+            first_part.append(point_from)
+            (coord_from, coord_to) = (Coordinates(*point_from), Coordinates(*point_to))
+            segment_length = distance(coord_from, coord_to)
+            if remaining_offset < segment_length:
+                splitpoint = interpolate([coord_from, coord_to], remaining_offset)
+                if splitpoint != coord_from:
+                    first_part.append(splitpoint)
+                second_part = [splitpoint, point_to]
+            remaining_offset -= segment_length
+        else:
+            second_part.append(point_to)
+    if splitpoint is None:
+        return (line, None)
+    first_part = LineString(first_part) if len(first_part) > 1 else None
+    second_part = LineString(second_part) if len(second_part) > 1 else None
+    return (first_part, second_part)
+
+
+def join_lines(lines: Sequence[LineString]) -> LineString:
+    coords = []
+    last = None
+
+    for l in lines:
+        cs = l.coords
+        first = cs[0]
+
+        if last is None:
+            coords.append(first)
+        else:
+            if first != last:
+                raise ValueError("Lines are not connected")
+
+        coords.extend(cs[1:])
+        last = cs[-1]
+
+    return LineString(coords)


### PR DESCRIPTION
Following up here from my discussion with @davidniedzielski-tomtom. 

Over the course of implementing a version of the OpenLR Python decoder for Streetlight Data, I made some changes that I thought might qualify as improvements, and that I thought might be worth contributing back to the project. All changes should be non-destructive or at least backwards compatible. In general the changes can be grouped into a few categories which I summarize here. From most to least important:

1. postgres map reader and primitives
2. optimize decoder to handle spatial inputs (segments + basemap) stored in equal-area projection 
3. new configs
    a) timeout for line decoding (default 50,000 s)
    b) equal-area SRID (default is 9311)
    c) equal-area flag (default is `False`)
5. object attribute caching and optimization to limit calls to db
6. auto-formatting <-- I can undo these changes if preferred, I had Python Black enabled when I made these changes so it auto-formatted things like line breaks, etc.

I appreciate the fact that the purpose of this repo was NOT for the code to be super performant, but instead simple and readable. While I don't think any of the changes I've proposed here are very complex, they _were_ designed to improve performance rather than readability, so I understand if they are not all deemed to be appropriate for a PR.